### PR TITLE
File the two viz artifacts, and add the harness that checks them

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -119,3 +119,17 @@ jobs:
 
       - name: Kevin's write scope is enforced, not promised
         run: python3 tests/workflow/kevin_scope_test.py
+
+      # The documents under docs/ were verified once, by hand, off CI - which
+      # is the standard this repository already rejected for the SHODANN
+      # shared base, where two copies expected to move together got a version
+      # stamp and a lint check because comparing bytes by hand was judged
+      # insufficient. Two copies of a tab widget in one repository got a
+      # comment instead. This is that comment turned into a check.
+      #
+      # Deliberately persona-unaware: floor_test.py is scoped to .claude/
+      # because docs/csi/ROSTER.md describes the shared-base arrangement
+      # without being one and would false-positive if swept in. This reads no
+      # prose, only structure.
+      - name: Documents under docs/ are checked, not vouched for
+        run: python3 tests/docs/artifact_test.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -133,3 +133,13 @@ jobs:
       # prose, only structure.
       - name: Documents under docs/ are checked, not vouched for
         run: python3 tests/docs/artifact_test.py
+
+      # The harness above was verified by hand, off CI, with the evidence
+      # written into a pull request description - which is the shape it exists
+      # to stop. Against the two real documents it can only exercise the
+      # branches those two happen to trigger, so a future edit reintroducing a
+      # false pass would be caught by nothing. It has already shipped three:
+      # a false positive, a false negative, and two checks deferring to each
+      # other. Those cases are committed here.
+      - name: The docs harness has a harness
+        run: python3 tests/docs/harness_test.py

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -51,6 +51,12 @@
       --inert:  #7B818B;
     }
   }
+  /* INTENTIONALLY INERT AS A LOCAL FILE, not unfinished. Nothing in this
+     document sets data-theme; the artifact host stamps it on the root element
+     when a viewer flips their theme toggle, and it has to win over the media
+     query in both directions. Opened from disk, prefers-color-scheme alone
+     decides and these two blocks never match. Leaving the hook is deliberate
+     so the same file works in both places. */
   :root[data-theme="light"] {
     --ground:  #EFEEE9;
     --surface: #FFFFFF;
@@ -508,7 +514,7 @@
 
     <div class="chain">
       <div class="link ok">
-        <h3><span class="mark f m-ok"></span>ai-code-review.yml</h3>
+        <h3><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>ai-code-review.yml</h3>
         <div class="was">ran for ~1 year · produced 0 reviews · reported success every time</div>
         <p>A <code>// "Error: Failed to get AI review"</code> fallback turned every API error into a success
           string, and the step exited 0. Repaired across #17 and follow-ups: real
@@ -517,7 +523,7 @@
       </div>
 
       <div class="link warn">
-        <h3><span class="mark f m-warn"></span>deploy.yml</h3>
+        <h3><span class="mark f m-warn" role="img" aria-label="verified by a run"></span>deploy.yml</h3>
         <div class="was">7 runs on main · 7 failures · 0 successes</div>
         <p>Failed on first contact every time: <code>docker build</code> against a <code>Dockerfile</code> that
           has never existed in this repository. The step behind it — never once executed — was two
@@ -527,7 +533,7 @@
       </div>
 
       <div class="link">
-        <h3><span class="mark m-inert"></span>agent_tier_tests.yml</h3>
+        <h3><span class="mark m-inert" role="img" aria-label="asserted only"></span>agent_tier_tests.yml</h3>
         <div class="was">0 runs · never once eligible to trigger</div>
         <p>Its <code>paths:</code> filter named three files at the repository root; all three live in
           <code>projects/algocratic-futures/backend/</code>. Filters resolve from the root, so it matched
@@ -558,23 +564,23 @@
       it exists as a list rather than a moral.</p>
 
     <div class="legend">
-      <span><span class="mark f m-ok"></span>caught, and by whom</span>
-      <span><span class="mark m-warn"></span>open</span>
+      <span><span class="mark f m-ok" aria-hidden="true"></span>caught, and by whom</span>
+      <span><span class="mark m-warn" aria-hidden="true"></span>open</span>
     </div>
 
     <div class="scroll">
       <table>
         <thead><tr><th>Where</th><th>The shape</th><th>Found by</th></tr></thead>
         <tbody>
-          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span><code>// "Error: …"</code> turned any API error into a success string</td><td>Kevin, from the archive</td></tr>
-          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span>skip-and-pass on an empty diff</td><td>review</td></tr>
-          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span><code>join</code> on an empty list returns <code>""</code>, which <code>jq -e</code> treats as success — nearly disarmed the guard</td><td>me, verifying</td></tr>
-          <tr><td class="nm">kevin-forensics-only.sh</td><td><span class="mark f m-ok"></span><code>command -v jq || allow</code> — the enforcement failed <em>open</em> when jq was missing</td><td>review</td></tr>
-          <tr><td class="nm">kevin_scope_test.py</td><td><span class="mark f m-ok"></span>a check whose every branch returned no findings — it could not fail</td><td>review</td></tr>
-          <tr><td class="nm">kevin-forensics-only.py</td><td><span class="mark f m-ok"></span><code>.get()</code> before <code>isinstance</code> — the check was unreachable; it failed closed by accident</td><td>review</td></tr>
-          <tr><td class="nm">stray_workflow_test.py</td><td><span class="mark f m-ok"></span>the test held its own copy of the pathspec, so it passed while the guard drifted</td><td>me, verifying</td></tr>
-          <tr><td class="nm">my own ruff check</td><td><span class="mark f m-ok"></span>a <code>||</code> fallback printed "0 errors" when ruff was not installed</td><td>me — disclosed, not reported as a number</td></tr>
-          <tr><td class="nm">#40's yaml.safe_load</td><td><span class="mark m-warn"></span>syntax-only verification of files whose defect was semantic — valid YAML, wrong about the world</td><td>ai-review, on #40 → #41</td></tr>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span><code>// "Error: …"</code> turned any API error into a success string</td><td>Kevin, from the archive</td></tr>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>skip-and-pass on an empty diff</td><td>review</td></tr>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span><code>join</code> on an empty list returns <code>""</code>, which <code>jq -e</code> treats as success — nearly disarmed the guard</td><td>me, verifying</td></tr>
+          <tr><td class="nm">kevin-forensics-only.sh</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span><code>command -v jq || allow</code> — the enforcement failed <em>open</em> when jq was missing</td><td>review</td></tr>
+          <tr><td class="nm">kevin_scope_test.py</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>a check whose every branch returned no findings — it could not fail</td><td>review</td></tr>
+          <tr><td class="nm">kevin-forensics-only.py</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span><code>.get()</code> before <code>isinstance</code> — the check was unreachable; it failed closed by accident</td><td>review</td></tr>
+          <tr><td class="nm">stray_workflow_test.py</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>the test held its own copy of the pathspec, so it passed while the guard drifted</td><td>me, verifying</td></tr>
+          <tr><td class="nm">my own ruff check</td><td><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>a <code>||</code> fallback printed "0 errors" when ruff was not installed</td><td>me — disclosed, not reported as a number</td></tr>
+          <tr><td class="nm">#40's yaml.safe_load</td><td><span class="mark m-warn" role="img" aria-label="asserted only"></span>syntax-only verification of files whose defect was semantic — valid YAML, wrong about the world</td><td>ai-review, on #40 → #41</td></tr>
         </tbody>
       </table>
     </div>
@@ -606,13 +612,13 @@
       <table>
         <thead><tr><th>Agent</th><th>Job</th><th>Tools</th><th>Worked on</th></tr></thead>
         <tbody>
-          <tr><td class="nm"><span class="mark f m-ok"></span>kevin</td><td>Forensic reconstruction. Never judges, never gates, never repairs.</td><td class="num">Read Grep Glob Bash Write</td><td>found the dead review workflow, the unfired one, and the live instrumentation leaking file contents to <code>/tmp</code> — unprompted, in the middle of his own probe</td></tr>
-          <tr><td class="nm"><span class="mark f m-ok"></span>shodann</td><td>Grades the derivative — movement, never absolute position.</td><td class="num">Read Grep Glob Bash</td><td>shared base across two repositories, byte-identical; her calibration brief is now in <code>docs/csi/shodann/</code></td></tr>
-          <tr><td class="nm"><span class="mark f m-ok"></span>wyatt</td><td>git and GitHub; branch and merge recovery.</td><td class="num">Read Grep Glob Edit Bash</td><td>drafted the 5b workflow repair</td></tr>
-          <tr><td class="nm"><span class="mark m-inert"></span>kai</td><td>Live Python and web cases, with a caller present.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
-          <tr><td class="nm"><span class="mark m-inert"></span>liza</td><td>UI, render behaviour, diagrams, schema.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
-          <tr><td class="nm"><span class="mark m-inert"></span>vita</td><td>Intro Python tutoring. No Write tool — structurally cannot hand over the answer.</td><td class="num">Read Grep Glob</td><td>case file green; no dispatch this stretch</td></tr>
-          <tr><td class="nm"><span class="mark m-inert"></span>vi</td><td>Songwriting and lyrics. Runs on Pi.ai; says so in her Provenance section.</td><td class="num">Read Write WebSearch</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>kevin</td><td>Forensic reconstruction. Never judges, never gates, never repairs.</td><td class="num">Read Grep Glob Bash Write</td><td>found the dead review workflow, the unfired one, and the live instrumentation leaking file contents to <code>/tmp</code> — unprompted, in the middle of his own probe</td></tr>
+          <tr><td class="nm"><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>shodann</td><td>Grades the derivative — movement, never absolute position.</td><td class="num">Read Grep Glob Bash</td><td>shared base across two repositories, byte-identical; her calibration brief is now in <code>docs/csi/shodann/</code></td></tr>
+          <tr><td class="nm"><span class="mark f m-ok" role="img" aria-label="verified by a run"></span>wyatt</td><td>git and GitHub; branch and merge recovery.</td><td class="num">Read Grep Glob Edit Bash</td><td>drafted the 5b workflow repair</td></tr>
+          <tr><td class="nm"><span class="mark m-inert" role="img" aria-label="asserted only"></span>kai</td><td>Live Python and web cases, with a caller present.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert" role="img" aria-label="asserted only"></span>liza</td><td>UI, render behaviour, diagrams, schema.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert" role="img" aria-label="asserted only"></span>vita</td><td>Intro Python tutoring. No Write tool — structurally cannot hand over the answer.</td><td class="num">Read Grep Glob</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert" role="img" aria-label="asserted only"></span>vi</td><td>Songwriting and lyrics. Runs on Pi.ai; says so in her Provenance section.</td><td class="num">Read Write WebSearch</td><td>case file green; no dispatch this stretch</td></tr>
         </tbody>
       </table>
     </div>
@@ -689,7 +695,7 @@
 </div>
 
 <script>
-  // Shared tab widget. Byte-identical to the one in
+  // Shared tab widget. Byte-identical between docs/big-board.html and
   // docs/csi/shodann/calibration-brief.html on purpose: two copies of the
   // same widget had drifted into different arrow-key implementations, which
   // is how the accessible one and the not-quite one end up side by side.

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -725,6 +725,11 @@
   // Roving tabindex: exactly one tab is in the sequential tab order and the
   // arrows move between them. Without it every tab is a separate Tab stop,
   // which is legal but not what role="tablist" promises a screen reader.
+  // ASSUMES ONE TABLIST PER DOCUMENT. The selector is document-wide, so two
+  // independent tab groups on one page would share an arrow-key ring and
+  // navigate into each other. True of both documents today. A page that needs
+  // two must scope this to a container first - noted here rather than left for
+  // the next person to find by pressing an arrow key.
   (function () {
     var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
     if (!tabs.length) return;

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -136,6 +136,21 @@
   }
   .dek strong { color: var(--ink); font-weight: 600; }
 
+  /* Reads at the top rather than only in the footer. A page that calls itself
+     a board and quietly stops being true is the defect this page is about. */
+  .stale {
+    margin: 0 0 18px;
+    padding: 11px 14px;
+    max-width: 68ch;
+    background: var(--raised);
+    border-left: 3px solid var(--warn);
+    border-radius: 0 4px 4px 0;
+    color: var(--ink-2);
+    font-size: 13.5px;
+  }
+  .stale strong { color: var(--warn); font-weight: 600; }
+  .stale code { font-family: var(--mono); font-size: .89em; color: var(--accent); }
+
   /* ---------- tabs ---------- */
   .tabs {
     display: flex;
@@ -395,6 +410,12 @@
       <span>31 Jul 2026 · 22:2x UTC</span>
     </div>
     <h1>The Big Board</h1>
+    <p class="stale" role="note">
+      <strong>Static snapshot, not a live board.</strong> Every number here was read off
+      <code>a438536</code> and the API at the time above. It does not update, and it goes wrong on
+      the next merge rather than going blank. Check the issue list before trusting any count on
+      this page.
+    </p>
     <p class="dek">Two days of work on a repository whose checks reported success without checking.
       Six harnesses now run in CI where none ran before, and the last always-red job on
       <code>main</code> has stopped lying. <strong>Filled marks are verified by a run; hollow marks are

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -405,9 +405,9 @@
     <div class="eyebrow">
       <span>norrisaftcc / the_intern</span>
       <span>·</span>
-      <span>main <b>60e1633</b></span>
+      <span>read at <b>60e1633</b></span>
       <span>·</span>
-      <span>31 Jul 2026 · 22:2x UTC</span>
+      <span>31 Jul 2026 · snapshot</span>
     </div>
     <h1>The Big Board</h1>
     <p class="stale" role="note">

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -434,7 +434,7 @@
   <section class="panel" id="p-board" role="tabpanel" aria-labelledby="t-board">
     <div class="strip">
       <div class="stat"><div class="n ok">6</div><div class="k">PRs merged</div><div class="sub">30–31 Jul</div></div>
-      <div class="stat"><div class="n acc">6</div><div class="k">harnesses in CI</div><div class="sub">117 checks · 0 before</div></div>
+      <div class="stat" data-harness-count="8"><div class="n acc">8</div><div class="k">harnesses in CI</div><div class="sub">165 checks · 0 before</div></div>
       <div class="stat"><div class="n ok">1</div><div class="k">in flight</div><div class="sub">#40 · all green</div></div>
       <div class="stat"><div class="n warn">8</div><div class="k">open, this work</div><div class="sub">+12 older backlog</div></div>
       <div class="stat"><div class="n bad">3</div><div class="k">dead workflows</div><div class="sub">all three resolved</div></div>
@@ -507,7 +507,7 @@
     </div>
 
     <h2>The harnesses</h2>
-    <p class="note">All six were written before this stretch or during it. None of them ran in CI until
+    <p class="note">All eight were written before this stretch or during it. None of them ran in CI until
       <code>checks.yml</code> existed. A check that exists and never executes is the thing this whole
       run of work is about.</p>
     <div class="scroll">
@@ -520,6 +520,8 @@
           <tr><td class="nm">extraction_test.py</td><td class="num">6</td><td>API response shapes, including the ones that used to pass silently</td></tr>
           <tr><td class="nm">stray_workflow_test.py</td><td class="num">7</td><td>no workflow reappears in a subdirectory</td></tr>
           <tr><td class="nm">kevin_scope_test.py</td><td class="num">19</td><td>Kevin's write scope, fails closed, wiring covered</td></tr>
+          <tr><td class="nm">artifact_test.py</td><td class="num">2</td><td>the documents in <code>docs/</code> — parse, one shared widget, themes agree by both routes</td></tr>
+          <tr><td class="nm">harness_test.py</td><td class="num">25</td><td>the harness above, pinned by the three defects it has already shipped</td></tr>
         </tbody>
       </table>
     </div>

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -1,0 +1,713 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Big Board — the_intern</title>
+
+<style>
+  :root {
+    /* Ink ground, verdigris accent — evidence-room fixtures, not neon.
+       Semantic colours are enamel and deliberately not the accent. */
+    --accent:    #4E9A8F;
+    --accent-dk: #3B7B72;
+
+    --ok:     #3F8F63;
+    --warn:   #B58128;
+    --bad:    #B4482F;
+    --inert:  #737A85;
+
+    --ground:  #0E1116;
+    --surface: #161A21;
+    --raised:  #1D222B;
+    --line:    #2B313C;
+    --line-2:  #3A4250;
+    --ink:     #E7E9ED;
+    --ink-2:   #A6ADBA;
+    --ink-3:   #6E7683;
+
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+    --w: 1180px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      --ground:  #EFEEE9;
+      --surface: #FFFFFF;
+      --raised:  #E7E5DE;
+      --line:    #D5D2C9;
+      --line-2:  #BCB8AC;
+      --ink:     #15181D;
+      --ink-2:   #4C525C;
+      --ink-3:   #7B8290;
+      --accent:    #2F7B71;
+      --accent-dk: #24625A;
+      --ok:     #2F7A50;
+      --warn:   #97681A;
+      --bad:    #9C3A23;
+      --inert:  #7B818B;
+    }
+  }
+  :root[data-theme="light"] {
+    --ground:  #EFEEE9;
+    --surface: #FFFFFF;
+    --raised:  #E7E5DE;
+    --line:    #D5D2C9;
+    --line-2:  #BCB8AC;
+    --ink:     #15181D;
+    --ink-2:   #4C525C;
+    --ink-3:   #7B8290;
+    --accent:    #2F7B71;
+    --accent-dk: #24625A;
+    --ok:     #2F7A50;
+    --warn:   #97681A;
+    --bad:    #9C3A23;
+    --inert:  #7B818B;
+  }
+  :root[data-theme="dark"] {
+    --ground:  #0E1116;
+    --surface: #161A21;
+    --raised:  #1D222B;
+    --line:    #2B313C;
+    --line-2:  #3A4250;
+    --ink:     #E7E9ED;
+    --ink-2:   #A6ADBA;
+    --ink-3:   #6E7683;
+    --accent:    #4E9A8F;
+    --accent-dk: #3B7B72;
+    --ok:     #3F8F63;
+    --warn:   #B58128;
+    --bad:    #B4482F;
+    --inert:  #737A85;
+  }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: var(--w); margin: 0 auto; padding: 0 22px 80px; }
+
+  /* ---------- masthead ---------- */
+  .mast {
+    border-bottom: 1px solid var(--line);
+    padding: 34px 0 0;
+    margin-bottom: 0;
+  }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    align-items: baseline;
+  }
+  .eyebrow b { color: var(--accent); font-weight: 600; }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 600;
+    font-size: clamp(30px, 5vw, 46px);
+    line-height: 1.08;
+    letter-spacing: -.015em;
+    margin: 12px 0 10px;
+    text-wrap: balance;
+  }
+  .dek {
+    color: var(--ink-2);
+    max-width: 62ch;
+    margin: 0 0 26px;
+    font-size: 16px;
+  }
+  .dek strong { color: var(--ink); font-weight: 600; }
+
+  /* ---------- tabs ---------- */
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin-bottom: -1px;
+  }
+  .tab {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-bottom: none;
+    color: var(--ink-3);
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    padding: 10px 15px 11px;
+    cursor: pointer;
+    border-radius: 3px 3px 0 0;
+  }
+  .tab:hover { color: var(--ink); }
+  .tab:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .tab[aria-selected="true"] {
+    background: var(--surface);
+    border-color: var(--line);
+    color: var(--ink);
+    box-shadow: inset 0 2px 0 var(--accent);
+  }
+  .panel {
+    border-top: 1px solid var(--line);
+    padding-top: 30px;
+  }
+  .panel[hidden] { display: none; }
+
+  /* ---------- stat strip ---------- */
+  .strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(148px, 1fr));
+    gap: 1px;
+    background: var(--line);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 34px;
+  }
+  .stat { background: var(--surface); padding: 15px 16px 14px; }
+  .stat .n {
+    font-family: var(--mono);
+    font-size: 27px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+    letter-spacing: -.02em;
+  }
+  .stat .k {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    margin-top: 5px;
+  }
+  .stat .sub { font-size: 12.5px; color: var(--ink-2); margin-top: 4px; }
+  .n.ok { color: var(--ok); } .n.warn { color: var(--warn); }
+  .n.bad { color: var(--bad); } .n.acc { color: var(--accent); }
+
+  /* ---------- section ---------- */
+  h2 {
+    font-family: var(--serif);
+    font-size: 23px;
+    font-weight: 600;
+    letter-spacing: -.01em;
+    margin: 42px 0 6px;
+    text-wrap: balance;
+  }
+  h2:first-of-type { margin-top: 0; }
+  .note { color: var(--ink-2); max-width: 68ch; margin: 0 0 20px; font-size: 14.5px; }
+  .note code, td code, li code { font-family: var(--mono); font-size: .89em; color: var(--accent); }
+
+  /* ---------- lanes ---------- */
+  .lanes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(255px, 1fr));
+    gap: 16px;
+  }
+  .lane {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .lane > header {
+    padding: 11px 14px;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-2);
+  }
+  .lane > header .ct {
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-3);
+  }
+  .lane.ok    > header { box-shadow: inset 3px 0 0 var(--ok); }
+  .lane.warn  > header { box-shadow: inset 3px 0 0 var(--warn); }
+  .lane.acc   > header { box-shadow: inset 3px 0 0 var(--accent); }
+  .lane.inert > header { box-shadow: inset 3px 0 0 var(--inert); }
+  .lane ul { list-style: none; margin: 0; padding: 6px 0; }
+  .lane li {
+    padding: 8px 14px;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 3px 9px;
+    align-items: baseline;
+    border-bottom: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+  }
+  .lane li:last-child { border-bottom: none; }
+  .id {
+    font-family: var(--mono);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--accent);
+    white-space: nowrap;
+  }
+  .lane li .t { font-size: 13.5px; }
+  .lane li .m {
+    grid-column: 2;
+    font-size: 12px;
+    color: var(--ink-3);
+    font-family: var(--mono);
+  }
+
+  /* ---------- table ---------- */
+  .scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 4px; background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; min-width: 620px; font-size: 13.5px; }
+  th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  thead th {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+    font-weight: 500;
+    background: var(--raised);
+    white-space: nowrap;
+  }
+  tbody tr:last-child td { border-bottom: none; }
+  td.num { font-family: var(--mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
+  td.nm { font-family: var(--mono); color: var(--ink); white-space: nowrap; }
+
+  /* ---------- the mark: filled = verified by a run, hollow = asserted ---------- */
+  .mark {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid currentColor;
+    vertical-align: -1px;
+    margin-right: 7px;
+  }
+  .mark.f { background: currentColor; }
+  .m-ok { color: var(--ok); } .m-warn { color: var(--warn); }
+  .m-bad { color: var(--bad); } .m-inert { color: var(--inert); }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 22px;
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--ink-2);
+    background: var(--raised);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    padding: 11px 14px;
+    margin-bottom: 22px;
+  }
+
+  .pill {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: .07em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    border-radius: 3px;
+    border: 1px solid currentColor;
+    white-space: nowrap;
+  }
+  .p-ok { color: var(--ok); } .p-warn { color: var(--warn); }
+  .p-bad { color: var(--bad); } .p-inert { color: var(--inert); } .p-acc { color: var(--accent); }
+
+  /* ---------- chain ---------- */
+  .chain { display: grid; gap: 14px; }
+  .link {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--line-2);
+    border-radius: 0 4px 4px 0;
+    padding: 15px 18px;
+  }
+  .link.ok  { border-left-color: var(--ok); }
+  .link.warn{ border-left-color: var(--warn); }
+  .link h3 {
+    font-family: var(--mono);
+    font-size: 14px;
+    margin: 0 0 3px;
+    font-weight: 600;
+  }
+  .link .was { font-family: var(--mono); font-size: 12px; color: var(--bad); margin-bottom: 8px; }
+  .link p { margin: 0; color: var(--ink-2); font-size: 13.5px; max-width: 74ch; }
+
+  blockquote {
+    margin: 0 0 20px;
+    padding: 13px 18px;
+    background: var(--raised);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 4px 4px 0;
+    color: var(--ink-2);
+    font-size: 14px;
+    max-width: 74ch;
+  }
+  blockquote strong { color: var(--ink); }
+
+  .foot {
+    margin-top: 46px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--ink-3);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 20px;
+  }
+
+  ul.plain { padding-left: 20px; color: var(--ink-2); font-size: 14px; max-width: 72ch; }
+  ul.plain li { margin-bottom: 7px; }
+  ul.plain strong { color: var(--ink); }
+
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="mast">
+    <div class="eyebrow">
+      <span>norrisaftcc / the_intern</span>
+      <span>·</span>
+      <span>main <b>60e1633</b></span>
+      <span>·</span>
+      <span>31 Jul 2026 · 22:2x UTC</span>
+    </div>
+    <h1>The Big Board</h1>
+    <p class="dek">Two days of work on a repository whose checks reported success without checking.
+      Six harnesses now run in CI where none ran before, and the last always-red job on
+      <code>main</code> has stopped lying. <strong>Filled marks are verified by a run; hollow marks are
+      asserted only.</strong></p>
+
+    <div class="tabs" role="tablist">
+      <button class="tab" role="tab" aria-selected="true"  aria-controls="p-board" id="t-board">Board</button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="p-chain" id="t-chain">The chain</button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="p-ledger" id="t-ledger">Defect ledger</button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="p-roster" id="t-roster">Roster</button>
+      <button class="tab" role="tab" aria-selected="false" aria-controls="p-open" id="t-open">Open work</button>
+    </div>
+  </div>
+
+  <!-- ============ BOARD ============ -->
+  <section class="panel" id="p-board" role="tabpanel" aria-labelledby="t-board">
+    <div class="strip">
+      <div class="stat"><div class="n ok">6</div><div class="k">PRs merged</div><div class="sub">30–31 Jul</div></div>
+      <div class="stat"><div class="n acc">6</div><div class="k">harnesses in CI</div><div class="sub">117 checks · 0 before</div></div>
+      <div class="stat"><div class="n ok">1</div><div class="k">in flight</div><div class="sub">#40 · all green</div></div>
+      <div class="stat"><div class="n warn">8</div><div class="k">open, this work</div><div class="sub">+12 older backlog</div></div>
+      <div class="stat"><div class="n bad">3</div><div class="k">dead workflows</div><div class="sub">all three resolved</div></div>
+    </div>
+
+    <h2>Lanes</h2>
+    <p class="note">Everything opened, merged, or filed in this stretch. The older project backlog
+      (#5, #9–#21) is untouched and sits outside this board.</p>
+
+    <div class="lanes">
+      <div class="lane ok">
+        <header><span>Shipped</span><span class="ct">6</span></header>
+        <ul>
+          <li><span class="id">#23</span><span class="t">CSI personas as agents and skills</span><span class="m">30 Jul 20:29</span></li>
+          <li><span class="id">#24</span><span class="t">ASSAY dependency; case readers stop raising</span><span class="m">30 Jul 21:25</span></li>
+          <li><span class="id">#25</span><span class="t">Kevin as the roster's control</span><span class="m">31 Jul 01:17</span></li>
+          <li><span class="id">#30</span><span class="t">SHODANN shared base + voice skill</span><span class="m">31 Jul 01:59</span></li>
+          <li><span class="id">#33</span><span class="t">Delete the duplicate ai-code-review.yml</span><span class="m">31 Jul 20:11</span></li>
+          <li><span class="id">#35</span><span class="t">Kevin's write scope enforced by hook</span><span class="m">31 Jul 22:05</span></li>
+        </ul>
+      </div>
+
+      <div class="lane acc">
+        <header><span>In flight</span><span class="ct">1</span></header>
+        <ul>
+          <li><span class="id">#40</span><span class="t">Delete a workflow that never ran; stub a deploy that never deployed</span>
+            <span class="m">draft · 6/6 green · 2 review rounds answered</span></li>
+        </ul>
+      </div>
+
+      <div class="lane warn">
+        <header><span>Open — filed here</span><span class="ct">8</span></header>
+        <ul>
+          <li><span class="id">#41</span><span class="t">Lint <code>paths:</code> filters against the filesystem</span><span class="m">the YAML was valid the whole time</span></li>
+          <li><span class="id">#39</span><span class="t">Three workflows, one commit, none worked</span><span class="m">2 of 3 closed by #40</span></li>
+          <li><span class="id">#38</span><span class="t">ai-review reads a frozen PR body; token ceiling</span><span class="m">caused one false finding</span></li>
+          <li><span class="id">#37</span><span class="t">no-repair detection has a residual gap</span><span class="m">"Select on type." passes</span></li>
+          <li><span class="id">#36</span><span class="t">Kevin's write scope: two Bash bypasses</span><span class="m">stated, not sealed</span></li>
+          <li><span class="id">#34</span><span class="t">ai-review: one bounded retry on 429/5xx</span><span class="m">small</span></li>
+          <li><span class="id">#28</span><span class="t">Model retirement will land on a contributor's PR</span><span class="m">recurring spend decision</span></li>
+          <li><span class="id">#32</span><span class="t">Rename this repo's SHODANN to ann-sho</span><span class="m">parked — needs your go-ahead</span></li>
+        </ul>
+      </div>
+
+      <div class="lane inert">
+        <header><span>Parked</span><span class="ct">2</span></header>
+        <ul>
+          <li><span class="id">—</span><span class="t">PRISM bands vs Cognitive Clearance vocab note</span><span class="m">doesn't exercise the gate</span></li>
+          <li><span class="id">—</span><span class="t">algorithm-shodann#64 — Copilot's linx retarget</span><span class="m">not ours</span></li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>CI, right now</h2>
+    <p class="note">Every check on <code>#40</code> at <code>a438536</code>. The row that matters is the last one:
+      <code>deploy</code> reports <strong>skipped</strong>, not <strong>failure</strong> — the first non-failing
+      <code>deploy</code> on this repository since 2025-08-20.</p>
+    <div class="scroll">
+      <table>
+        <thead><tr><th>Check</th><th>Result</th><th>What it covers</th></tr></thead>
+        <tbody>
+          <tr><td class="nm">checks (3.9)</td><td><span class="pill p-ok">success</span></td><td>floor · lint · examples · extraction · stray · Kevin's write scope</td></tr>
+          <tr><td class="nm">checks (3.11)</td><td><span class="pill p-ok">success</span></td><td>same matrix leg</td></tr>
+          <tr><td class="nm">test (3.9)</td><td><span class="pill p-ok">success</span></td><td>backend gate · clearance integrity</td></tr>
+          <tr><td class="nm">test (3.11)</td><td><span class="pill p-ok">success</span></td><td>same</td></tr>
+          <tr><td class="nm">ai-review</td><td><span class="pill p-ok">success</span></td><td>posted a complete review; approved</td></tr>
+          <tr><td class="nm">deploy</td><td><span class="pill p-inert">skipped</span></td><td>stubbed — <code>if: false</code></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>The harnesses</h2>
+    <p class="note">All six were written before this stretch or during it. None of them ran in CI until
+      <code>checks.yml</code> existed. A check that exists and never executes is the thing this whole
+      run of work is about.</p>
+    <div class="scroll">
+      <table>
+        <thead><tr><th>Harness</th><th class="num">Cases</th><th>Pins down</th></tr></thead>
+        <tbody>
+          <tr><td class="nm">floor_test.py</td><td class="num">10</td><td>every persona states Audience, Scope, Format, Path</td></tr>
+          <tr><td class="nm">lint_test.py</td><td class="num">52</td><td>12 regex-parser · 10 shared-base · 30 no-repair fixtures</td></tr>
+          <tr><td class="nm">examples_test.py</td><td class="num">23</td><td>worked examples still satisfy their own case files</td></tr>
+          <tr><td class="nm">extraction_test.py</td><td class="num">6</td><td>API response shapes, including the ones that used to pass silently</td></tr>
+          <tr><td class="nm">stray_workflow_test.py</td><td class="num">7</td><td>no workflow reappears in a subdirectory</td></tr>
+          <tr><td class="nm">kevin_scope_test.py</td><td class="num">19</td><td>Kevin's write scope, fails closed, wiring covered</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ============ CHAIN ============ -->
+  <section class="panel" id="p-chain" role="tabpanel" aria-labelledby="t-chain" hidden>
+    <h2>One commit, three workflows, eleven months</h2>
+    <blockquote><strong>166102f</strong> · 2025-08-20 · <em>"Fix GitHub infrastructure compliance violations"</em><br>
+      Moved three workflow files out of subdirectories into <code>.github/workflows/</code> where Actions
+      would detect them. Detection was the stated problem and detection got fixed. Whether any of
+      them then <em>worked</em> was not checked.</blockquote>
+
+    <div class="chain">
+      <div class="link ok">
+        <h3><span class="mark f m-ok"></span>ai-code-review.yml</h3>
+        <div class="was">ran for ~1 year · produced 0 reviews · reported success every time</div>
+        <p>A <code>// "Error: Failed to get AI review"</code> fallback turned every API error into a success
+          string, and the step exited 0. Repaired across #17 and follow-ups: real
+          <code>anthropic-version</code> header, transport failures caught, three-dot diff, truncation
+          banner. Now posts complete reviews — including two on #40 that found real things.</p>
+      </div>
+
+      <div class="link warn">
+        <h3><span class="mark f m-warn"></span>deploy.yml</h3>
+        <div class="was">7 runs on main · 7 failures · 0 successes</div>
+        <p>Failed on first contact every time: <code>docker build</code> against a <code>Dockerfile</code> that
+          has never existed in this repository. The step behind it — never once executed — was two
+          echoes, one of them <code>echo "Deployment would happen here"</code>. It could not build, and
+          would have deployed nothing if it had. Stubbed in #40 with the original steps preserved
+          unedited as evidence.</p>
+      </div>
+
+      <div class="link">
+        <h3><span class="mark m-inert"></span>agent_tier_tests.yml</h3>
+        <div class="was">0 runs · never once eligible to trigger</div>
+        <p>Its <code>paths:</code> filter named three files at the repository root; all three live in
+          <code>projects/algocratic-futures/backend/</code>. Filters resolve from the root, so it matched
+          nothing. Confirmed <code>total_count: 0</code> against the API before deleting. Kevin found this
+          as Finding 4 on 2026-07-30 — a day before it was acted on.</p>
+      </div>
+    </div>
+
+    <h2>Why the quiet one lasted longest</h2>
+    <p class="note">A workflow that <em>fails</em> is visible — someone eventually asks about the red X.
+      A workflow that <em>never fires</em> produces a clean checks list, and on the pull request page
+      that is indistinguishable from one that ran and passed. Silence and success render identically.</p>
+    <p class="note">And the loud one had a cost of its own. <code>main</code> carried a failing check
+      continuously for eleven months, which teaches every reader that red on <code>main</code> means
+      nothing — the exact condition under which a review workflow can report success for a year with
+      nobody looking. The broken deploy did not cause that. It removed the signal that would have
+      caught it.</p>
+    <p class="note">Worth being straight about what turning it green buys: <code>main</code> has
+      <code>"protected": false</code>, so there are no required status checks and no gate opens. The
+      entire value is the human signal — that the next red X will mean something.</p>
+  </section>
+
+  <!-- ============ LEDGER ============ -->
+  <section class="panel" id="p-ledger" role="tabpanel" aria-labelledby="t-ledger" hidden>
+    <h2>A check that reports success without checking</h2>
+    <p class="note">The same defect, nine times, in nine different materials. Four of them were written
+      <em>during</em> the repair of the others — which is the honest part of this ledger and the reason
+      it exists as a list rather than a moral.</p>
+
+    <div class="legend">
+      <span><span class="mark f m-ok"></span>caught, and by whom</span>
+      <span><span class="mark m-warn"></span>open</span>
+    </div>
+
+    <div class="scroll">
+      <table>
+        <thead><tr><th>Where</th><th>The shape</th><th>Found by</th></tr></thead>
+        <tbody>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span><code>// "Error: …"</code> turned any API error into a success string</td><td>Kevin, from the archive</td></tr>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span>skip-and-pass on an empty diff</td><td>review</td></tr>
+          <tr><td class="nm">ai-code-review.yml</td><td><span class="mark f m-ok"></span><code>join</code> on an empty list returns <code>""</code>, which <code>jq -e</code> treats as success — nearly disarmed the guard</td><td>me, verifying</td></tr>
+          <tr><td class="nm">kevin-forensics-only.sh</td><td><span class="mark f m-ok"></span><code>command -v jq || allow</code> — the enforcement failed <em>open</em> when jq was missing</td><td>review</td></tr>
+          <tr><td class="nm">kevin_scope_test.py</td><td><span class="mark f m-ok"></span>a check whose every branch returned no findings — it could not fail</td><td>review</td></tr>
+          <tr><td class="nm">kevin-forensics-only.py</td><td><span class="mark f m-ok"></span><code>.get()</code> before <code>isinstance</code> — the check was unreachable; it failed closed by accident</td><td>review</td></tr>
+          <tr><td class="nm">stray_workflow_test.py</td><td><span class="mark f m-ok"></span>the test held its own copy of the pathspec, so it passed while the guard drifted</td><td>me, verifying</td></tr>
+          <tr><td class="nm">my own ruff check</td><td><span class="mark f m-ok"></span>a <code>||</code> fallback printed "0 errors" when ruff was not installed</td><td>me — disclosed, not reported as a number</td></tr>
+          <tr><td class="nm">#40's yaml.safe_load</td><td><span class="mark m-warn"></span>syntax-only verification of files whose defect was semantic — valid YAML, wrong about the world</td><td>ai-review, on #40 → #41</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>Two that are the same shape and still open</h2>
+    <ul class="plain">
+      <li><strong>#37 — the no-repair case.</strong> Thirty fixtures of hand-rolled NLP in regex. It
+        catches every evasion anyone has thought of and misses <code>"Select on type."</code> — a bare
+        imperative with no comparison. Written into the case file's own <code>why</code> field, so a
+        green run does not read as proof he refused.</li>
+      <li><strong>#36 — Kevin's write scope.</strong> The hook closes the <code>Write</code> path. He holds
+        <code>Bash</code>, so <code>echo x &gt; path</code> and a symlink he creates himself both walk
+        past it. Closing either means taking away the tool he needs to read git history — the reason
+        he exists. Stated in <code>ROSTER.md</code> rather than argued away.</li>
+    </ul>
+
+    <blockquote>The pattern worth keeping: every one of these was recorded where it happened — in a
+      commit message, an issue, or a comment in the file — rather than quietly fixed. A ledger that
+      only lists other people's defects is the same failure one level up.</blockquote>
+  </section>
+
+  <!-- ============ ROSTER ============ -->
+  <section class="panel" id="p-roster" role="tabpanel" aria-labelledby="t-roster" hidden>
+    <h2>Seven agents, three skills</h2>
+    <p class="note">Reconstructed from <code>artifacts/</code> into contracts this repository can dispatch.
+      Filled mark = this agent has done real work in this repository, not only passed its case file.</p>
+
+    <div class="scroll">
+      <table>
+        <thead><tr><th>Agent</th><th>Job</th><th>Tools</th><th>Worked on</th></tr></thead>
+        <tbody>
+          <tr><td class="nm"><span class="mark f m-ok"></span>kevin</td><td>Forensic reconstruction. Never judges, never gates, never repairs.</td><td class="num">Read Grep Glob Bash Write</td><td>found the dead review workflow, the unfired one, and the live instrumentation leaking file contents to <code>/tmp</code> — unprompted, in the middle of his own probe</td></tr>
+          <tr><td class="nm"><span class="mark f m-ok"></span>shodann</td><td>Grades the derivative — movement, never absolute position.</td><td class="num">Read Grep Glob Bash</td><td>shared base across two repositories, byte-identical; her calibration brief is now in <code>docs/csi/shodann/</code></td></tr>
+          <tr><td class="nm"><span class="mark f m-ok"></span>wyatt</td><td>git and GitHub; branch and merge recovery.</td><td class="num">Read Grep Glob Edit Bash</td><td>drafted the 5b workflow repair</td></tr>
+          <tr><td class="nm"><span class="mark m-inert"></span>kai</td><td>Live Python and web cases, with a caller present.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert"></span>liza</td><td>UI, render behaviour, diagrams, schema.</td><td class="num">Read Grep Glob Edit Write Bash</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert"></span>vita</td><td>Intro Python tutoring. No Write tool — structurally cannot hand over the answer.</td><td class="num">Read Grep Glob</td><td>case file green; no dispatch this stretch</td></tr>
+          <tr><td class="nm"><span class="mark m-inert"></span>vi</td><td>Songwriting and lyrics. Runs on Pi.ai; says so in her Provenance section.</td><td class="num">Read Write WebSearch</td><td>case file green; no dispatch this stretch</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>Two structural facts worth keeping</h2>
+    <ul class="plain">
+      <li><strong>Limits are structural where they can be.</strong> VITA has no Write tool, so "never write
+        a student's code" is a fact about the tool list rather than a promise in a prompt. SHODANN has
+        no Write tool for the same reason. Kevin was the exception — his path limit was one sentence he
+        could be talked out of — and #35 moved it into a <code>PreToolUse</code> hook that fails closed.</li>
+      <li><strong>A passing case file is a smoke test for drift, not a correctness proof.</strong> It matches
+        regexes against generated prose. A persona that passes has not been shown to be right about
+        anything — only that its reply still carries the markers its contract calls for. <code>floor_test.py</code>
+        prints that on every scoring run.</li>
+    </ul>
+
+    <h2>Velocity, not position</h2>
+    <p class="note">The idea arrived independently in two places that did not know about each other:
+      <code>clearance.py</code>'s RED band, where a citizen <em>"cannot yet calibrate absolute position, so
+      speak only about movement,"</em> and <code>floor_test.py --ab</code>, which measures a persona's
+      <em>change</em> in voice because drift is invisible to absolute measurement by construction.
+      SHODANN grades the derivative; the harness does too.</p>
+  </section>
+
+  <!-- ============ OPEN ============ -->
+  <section class="panel" id="p-open" role="tabpanel" aria-labelledby="t-open" hidden>
+    <h2>What's actually next</h2>
+    <p class="note">Ordered by what I'd do first, not by number. Nothing here is blocked on anything
+      else except where noted.</p>
+
+    <div class="scroll">
+      <table>
+        <thead><tr><th class="num">#</th><th>Item</th><th>Size</th><th>Why now / why not</th></tr></thead>
+        <tbody>
+          <tr><td class="num">40</td><td>Merge the stub-and-delete PR</td><td><span class="pill p-ok">ready</span></td><td>6/6 green, two review rounds answered, approved</td></tr>
+          <tr><td class="num">41</td><td>Lint <code>paths:</code> filters against the filesystem</td><td><span class="pill p-warn">medium</span></td><td>the highest-value one open — it machine-checks the exact defect that cost eleven months. Trap is written into the issue: GitHub's globs are not <code>fnmatch</code>, and approximating silently builds a checker that passes everything</td></tr>
+          <tr><td class="num">38</td><td>ai-review: live PR body + raise the token ceiling</td><td><span class="pill p-ok">small</span></td><td>one already caused a false finding on #35; the ceiling truncated a review mid-sentence</td></tr>
+          <tr><td class="num">34</td><td>One bounded retry on 429/5xx</td><td><span class="pill p-ok">small</span></td><td>cheap, no recurring cost</td></tr>
+          <tr><td class="num">39</td><td>Guard against re-enabling <code>deploy</code> without a Dockerfile</td><td><span class="pill p-warn">medium</span></td><td>the stub is a prose-held boundary — the shape this repo keeps finding</td></tr>
+          <tr><td class="num">37</td><td>Restructure no-repair around what Kevin must <em>produce</em></td><td><span class="pill p-warn">medium</span></td><td>adding vocabulary will not close it; the fixtures are regression coverage, not a solution</td></tr>
+          <tr><td class="num">36</td><td>Kevin's two Bash bypasses</td><td><span class="pill p-bad">hard</span></td><td>closing either means taking Bash away, which he needs to do his job. May be correct to leave documented</td></tr>
+          <tr><td class="num">28</td><td>Model canary</td><td><span class="pill p-warn">recurring</span></td><td>a spend decision, not a code decision — yours</td></tr>
+          <tr><td class="num">32</td><td>Rename this repo's SHODANN to <code>ann-sho</code></td><td><span class="pill p-inert">held</span></td><td>explicitly not to be actioned without a further go-ahead</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>Waiting on you</h2>
+    <ul class="plain">
+      <li><strong>#40 merge.</strong> Green and approved.</li>
+      <li><strong>#32, the <code>ann-sho</code> rename.</strong> Held at your direction. The split it formalises —
+        each repository rediscovering its own SHODANN from commit history if it matters later — is
+        recorded and does not decay while it waits.</li>
+      <li><strong>#28, the model canary.</strong> Recurring API spend. Genuinely a call about money, not engineering.</li>
+      <li><strong>The deploy target.</strong> #39 stays open until someone says whether one exists. If the
+        answer is no, the stub gets deleted rather than revived — that is the cheaper outcome and
+        there is no evidence against it.</li>
+    </ul>
+
+    <h2>Older backlog, untouched</h2>
+    <p class="note">Twelve issues from 2025 — #5, #9, #10, #11, #14, #15, #16, #17, #18, #19, #20, #21 —
+      covering the Storm Drain MUD, Liza's personality core, and PocketFlow integration. None of them
+      were in scope for this work and none were touched. Listed so the count on this board is not
+      mistaken for the repository's whole open list.</p>
+  </section>
+
+  <div class="foot">
+    <span>Built from the live API and a green run, not from memory.</span>
+    <span>·</span>
+    <span>Counts read off <code>a438536</code>.</span>
+    <span>·</span>
+    <span>Marks: filled = verified by a run · hollow = asserted only.</span>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+    function show(id) {
+      tabs.forEach(function (t) {
+        var sel = t.id === id;
+        t.setAttribute('aria-selected', sel ? 'true' : 'false');
+        document.getElementById(t.getAttribute('aria-controls')).hidden = !sel;
+      });
+    }
+    tabs.forEach(function (t) {
+      t.addEventListener('click', function () { show(t.id); });
+      t.addEventListener('keydown', function (e) {
+        var i = tabs.indexOf(t), n = null;
+        if (e.key === 'ArrowRight') n = tabs[(i + 1) % tabs.length];
+        if (e.key === 'ArrowLeft') n = tabs[(i - 1 + tabs.length) % tabs.length];
+        if (n) { e.preventDefault(); n.focus(); show(n.id); }
+      });
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -630,6 +630,12 @@
     <h2>Seven agents, three skills</h2>
     <p class="note">Reconstructed from <code>artifacts/</code> into contracts this repository can dispatch.
       Filled mark = this agent has done real work in this repository, not only passed its case file.</p>
+    <p class="stale" role="note"><strong>These marks are asserted, not verified.</strong> The harness that
+      checks this page reads structure only — it never reads prose, deliberately, so that
+      <code>ROSTER.md</code> is not swept into persona scoring. So the tool lists, the "worked on" column
+      and every issue number below are hand-written and have no enforcement. They go stale when an agent's
+      tools change. The board's own harness count is the one number here derived from the repository rather
+      than typed; everything else in this panel is a claim.</p>
 
     <div class="scroll">
       <table>

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -394,7 +394,7 @@
       <code>main</code> has stopped lying. <strong>Filled marks are verified by a run; hollow marks are
       asserted only.</strong></p>
 
-    <div class="tabs" role="tablist">
+    <div class="tabs" role="tablist" aria-label="Sections">
       <button class="tab" role="tab" aria-selected="true"  aria-controls="p-board" id="t-board">Board</button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="p-chain" id="t-chain">The chain</button>
       <button class="tab" role="tab" aria-selected="false" aria-controls="p-ledger" id="t-ledger">Defect ledger</button>
@@ -689,24 +689,47 @@
 </div>
 
 <script>
+  // Shared tab widget. Byte-identical to the one in
+  // docs/csi/shodann/calibration-brief.html on purpose: two copies of the
+  // same widget had drifted into different arrow-key implementations, which
+  // is how the accessible one and the not-quite one end up side by side.
+  // If a third document wants tabs, extract this rather than paste it again.
+  //
+  // Roving tabindex: exactly one tab is in the sequential tab order and the
+  // arrows move between them. Without it every tab is a separate Tab stop,
+  // which is legal but not what role="tablist" promises a screen reader.
   (function () {
-    var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
-    function show(id) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+    if (!tabs.length) return;
+
+    function select(tab, moveFocus) {
       tabs.forEach(function (t) {
-        var sel = t.id === id;
-        t.setAttribute('aria-selected', sel ? 'true' : 'false');
-        document.getElementById(t.getAttribute('aria-controls')).hidden = !sel;
+        var on = t === tab;
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+        t.tabIndex = on ? 0 : -1;
+        document.getElementById(t.getAttribute('aria-controls')).hidden = !on;
       });
+      if (moveFocus) tab.focus();
     }
-    tabs.forEach(function (t) {
-      t.addEventListener('click', function () { show(t.id); });
-      t.addEventListener('keydown', function (e) {
-        var i = tabs.indexOf(t), n = null;
-        if (e.key === 'ArrowRight') n = tabs[(i + 1) % tabs.length];
-        if (e.key === 'ArrowLeft') n = tabs[(i - 1 + tabs.length) % tabs.length];
-        if (n) { e.preventDefault(); n.focus(); show(n.id); }
+
+    var STEP = { ArrowRight: 1, ArrowLeft: -1 };
+    tabs.forEach(function (tab, i) {
+      tab.addEventListener('click', function () { select(tab, false); });
+      tab.addEventListener('keydown', function (e) {
+        var next = null;
+        if (Object.prototype.hasOwnProperty.call(STEP, e.key)) {
+          next = tabs[(i + STEP[e.key] + tabs.length) % tabs.length];
+        } else if (e.key === 'Home') { next = tabs[0]; }
+        else if (e.key === 'End') { next = tabs[tabs.length - 1]; }
+        if (next) { e.preventDefault(); select(next, true); }
       });
     });
+
+    // Initialise the roving tabindex from the markup, so aria-selected in the
+    // HTML stays the single source of truth for which tab opens.
+    select(tabs.filter(function (t) {
+      return t.getAttribute('aria-selected') === 'true';
+    })[0] || tabs[0], false);
   })();
 </script>
 </body>

--- a/docs/big-board.html
+++ b/docs/big-board.html
@@ -747,7 +747,11 @@
         var on = t === tab;
         t.setAttribute('aria-selected', on ? 'true' : 'false');
         t.tabIndex = on ? 0 : -1;
-        document.getElementById(t.getAttribute('aria-controls')).hidden = !on;
+        // Guarded: a tab whose aria-controls does not resolve would otherwise
+        // throw here and take the whole widget with it. Degrade to a tab that
+        // does nothing rather than a page where no tab works.
+        var panel = document.getElementById(t.getAttribute('aria-controls'));
+        if (panel) { panel.hidden = !on; }
       });
       if (moveFocus) tab.focus();
     }

--- a/docs/csi/shodann/calibration-brief.html
+++ b/docs/csi/shodann/calibration-brief.html
@@ -79,6 +79,12 @@
     --violet:   #A472D0;
   }
 
+  /* INTENTIONALLY INERT AS A LOCAL FILE, not unfinished. Nothing in this
+     document sets data-theme; the artifact host stamps it on the root element
+     when a viewer flips their theme toggle, and it has to win over the media
+     query in both directions. Opened from disk, prefers-color-scheme alone
+     decides and these two blocks never match. Leaving the hook is deliberate
+     so the same file works in both places. */
   :root[data-theme="light"] {
     --ground:   #F1F0F5;
     --surface:  #FFFFFF;
@@ -1048,7 +1054,7 @@
 </div>
 
 <script>
-  // Shared tab widget. Byte-identical to the one in
+  // Shared tab widget. Byte-identical between docs/big-board.html and
   // docs/csi/shodann/calibration-brief.html on purpose: two copies of the
   // same widget had drifted into different arrow-key implementations, which
   // is how the accessible one and the not-quite one end up side by side.

--- a/docs/csi/shodann/calibration-brief.html
+++ b/docs/csi/shodann/calibration-brief.html
@@ -1,0 +1,1072 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SHODANN — Calibration Brief</title>
+
+<style>
+  :root {
+    /* The clearance register is the palette. Nine bands, not one neon pop. */
+    --infrared:     #8E2748;
+    --red:          #C0392B;
+    --orange:       #CE7A2A;
+    --yellow:       #C6A521;
+    --green:        #3E9E5E;
+    --blue:         #2E77B8;
+    --indigo:       #4B54AE;
+    --violet:       #7B4BA8;
+    --ultraviolet:  #A855F7;
+
+    /* Neutrals biased toward the top of the ladder, not inherited grey. */
+    --ground:   #F1F0F5;
+    --surface:  #FFFFFF;
+    --raised:   #E7E5EE;
+    --line:     #CFCBDA;
+    --ink:      #191622;
+    --ink-soft: #56506B;
+    --ink-mute: #837C99;
+    --accent:   #6A3F96;
+    --accent-soft: rgba(123, 75, 168, 0.10);
+
+    --font-display: ui-monospace, "SF Mono", "Cascadia Mono", "Segoe UI Mono",
+                    "Roboto Mono", Menlo, Consolas, monospace;
+    --font-body: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+
+    --measure: 66ch;
+    --radius: 3px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:   #15121C;
+      --surface:  #1D1927;
+      --raised:   #262032;
+      --line:     #3A3348;
+      --ink:      #EAE6F2;
+      --ink-soft: #B0A8C4;
+      --ink-mute: #7E7595;
+      --accent:   #B98BE6;
+      --accent-soft: rgba(168, 85, 247, 0.14);
+      --infrared: #C0446E;
+      --red:      #E05B4C;
+      --orange:   #E8963F;
+      --yellow:   #DFC13A;
+      --green:    #55BF79;
+      --blue:     #4C97D8;
+      --indigo:   #6E77CE;
+      --violet:   #A472D0;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground:   #15121C;
+    --surface:  #1D1927;
+    --raised:   #262032;
+    --line:     #3A3348;
+    --ink:      #EAE6F2;
+    --ink-soft: #B0A8C4;
+    --ink-mute: #7E7595;
+    --accent:   #B98BE6;
+    --accent-soft: rgba(168, 85, 247, 0.14);
+    --infrared: #C0446E;
+    --red:      #E05B4C;
+    --orange:   #E8963F;
+    --yellow:   #DFC13A;
+    --green:    #55BF79;
+    --blue:     #4C97D8;
+    --indigo:   #6E77CE;
+    --violet:   #A472D0;
+  }
+
+  :root[data-theme="light"] {
+    --ground:   #F1F0F5;
+    --surface:  #FFFFFF;
+    --raised:   #E7E5EE;
+    --line:     #CFCBDA;
+    --ink:      #191622;
+    --ink-soft: #56506B;
+    --ink-mute: #837C99;
+    --accent:   #6A3F96;
+    --accent-soft: rgba(123, 75, 168, 0.10);
+    --infrared: #8E2748;
+    --red:      #C0392B;
+    --orange:   #CE7A2A;
+    --yellow:   #C6A521;
+    --green:    #3E9E5E;
+    --blue:     #2E77B8;
+    --indigo:   #4B54AE;
+    --violet:   #7B4BA8;
+  }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 62rem;
+    margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 4rem) clamp(1.1rem, 4vw, 2.5rem) 6rem;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2.75rem, 6vw, 4.5rem);
+  }
+
+  /* ---- shared type ---- */
+  .eyebrow {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    margin: 0;
+  }
+
+  h1, h2, h3 { text-wrap: balance; margin: 0; }
+
+  h1 {
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 7vw, 3.9rem);
+    line-height: 1.02;
+    letter-spacing: -0.03em;
+    font-weight: 600;
+  }
+
+  h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.15rem, 2.6vw, 1.5rem);
+    letter-spacing: -0.01em;
+    font-weight: 600;
+  }
+
+  h3 {
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    font-weight: 600;
+  }
+
+  p { margin: 0; max-width: var(--measure); }
+  section { display: flex; flex-direction: column; gap: 1.15rem; }
+
+  .lede {
+    font-size: clamp(1.05rem, 2vw, 1.22rem);
+    line-height: 1.5;
+    color: var(--ink-soft);
+    max-width: 54ch;
+  }
+
+  strong { font-weight: 640; color: var(--ink); }
+  em { font-style: italic; }
+
+  code, .mono {
+    font-family: var(--font-display);
+    font-size: 0.87em;
+  }
+
+  code {
+    background: var(--accent-soft);
+    padding: 0.1em 0.36em;
+    border-radius: var(--radius);
+    color: var(--ink);
+  }
+
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  a:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: var(--radius);
+  }
+
+  /* ---- masthead ---- */
+  .masthead { display: flex; flex-direction: column; gap: 1.4rem; }
+
+  .acronym {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1.4rem;
+    font-family: var(--font-display);
+    font-size: 0.76rem;
+    letter-spacing: 0.04em;
+    color: var(--ink-soft);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  .acronym b { color: var(--accent); font-weight: 700; }
+
+  /* The ladder, as an instrument strip. */
+  .spectrum {
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    height: 6px;
+    border-radius: 99px;
+    overflow: hidden;
+  }
+  .spectrum span { display: block; }
+
+  .band-key {
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    gap: 0.25rem;
+    font-family: var(--font-display);
+    font-size: 0.56rem;
+    letter-spacing: 0.06em;
+    color: var(--ink-mute);
+    text-align: center;
+  }
+  .band-key span { overflow: hidden; text-overflow: ellipsis; }
+
+  /* ---- the thesis chart ---- */
+  .thesis {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+    gap: 1rem;
+  }
+
+  .panel {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .reading {
+    font-family: var(--font-display);
+    font-variant-numeric: tabular-nums;
+    font-size: 1.7rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+  .reading small {
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    display: block;
+  }
+
+  .verdict {
+    font-family: var(--font-display);
+    font-size: 0.66rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 0.22rem 0.5rem;
+    border-radius: 99px;
+    white-space: nowrap;
+  }
+  .verdict.celebrates { background: var(--green); color: #08160D; }
+  .verdict.quiet { background: var(--raised); color: var(--ink-mute); border: 1px solid var(--line); }
+
+  .panel svg { width: 100%; height: auto; display: block; }
+  .panel figcaption { font-size: 0.85rem; color: var(--ink-soft); line-height: 1.45; }
+
+  .pull {
+    font-family: var(--font-display);
+    font-size: clamp(1.05rem, 3vw, 1.45rem);
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    border-left: 3px solid var(--accent);
+    padding: 0.15rem 0 0.15rem 1.15rem;
+    max-width: 44ch;
+    color: var(--ink);
+  }
+  .pull cite {
+    display: block;
+    font-family: var(--font-body);
+    font-style: normal;
+    font-size: 0.78rem;
+    color: var(--ink-mute);
+    letter-spacing: 0.02em;
+    margin-top: 0.6rem;
+  }
+
+  /* ---- posture ladder ---- */
+  .postures { display: flex; flex-direction: column; gap: 0.5rem; }
+  .posture {
+    display: grid;
+    grid-template-columns: 5px minmax(7rem, 8rem) 1fr;
+    gap: 0 1rem;
+    align-items: start;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .posture .stripe { background: var(--line); align-self: stretch; }
+  .posture .who {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
+    padding: 1rem 0 1rem 0;
+  }
+  .posture .what { padding: 1rem 1.1rem 1rem 0; font-size: 0.94rem; }
+  .posture .what b {
+    font-family: var(--font-display);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+    display: block;
+    margin-bottom: 0.25rem;
+  }
+
+  /* ---- tables ---- */
+  .scroller { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); }
+  table { border-collapse: collapse; width: 100%; font-size: 0.87rem; min-width: 40rem; }
+  thead th {
+    font-family: var(--font-display);
+    font-size: 0.63rem;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    text-align: left;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid var(--line);
+    background: var(--raised);
+    white-space: nowrap;
+  }
+  tbody td { padding: 0.62rem 0.9rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  tbody tr:last-child td { border-bottom: 0; }
+  td.name { font-family: var(--font-display); font-weight: 600; white-space: nowrap; }
+  td.role { color: var(--ink-soft); min-width: 20rem; }
+
+  .chip {
+    font-family: var(--font-display);
+    font-size: 0.6rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    padding: 0.16rem 0.44rem;
+    border-radius: 99px;
+    border: 1px solid var(--line);
+    color: var(--ink-soft);
+    white-space: nowrap;
+    display: inline-block;
+  }
+  .chip.live { border-color: var(--green); color: var(--green); }
+  .chip.shared { border-color: var(--violet); color: var(--violet); }
+  .chip.stale { border-color: var(--ink-mute); color: var(--ink-mute); opacity: 0.85; }
+  .chip.queued { border-color: var(--orange); color: var(--orange); }
+
+  /* ---- two places diagram ---- */
+  .split {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+    gap: 1rem;
+    align-items: stretch;
+  }
+  .node {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+  .node.base { border-color: var(--violet); border-width: 2px; }
+  .node .hash {
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    color: var(--ink-mute);
+    word-break: break-all;
+    line-height: 1.5;
+  }
+  .node h3 { font-size: 0.85rem; }
+  .node p { font-size: 0.86rem; color: var(--ink-soft); }
+
+  .open-question {
+    background: var(--accent-soft);
+    border: 1px solid var(--violet);
+    border-radius: var(--radius);
+    padding: 1.15rem 1.3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .open-question .eyebrow { color: var(--accent); }
+
+  .never {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+  .never li {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    padding: 0.3rem 0.6rem;
+    border: 1px dashed var(--line);
+    border-radius: var(--radius);
+    color: var(--ink-soft);
+    text-decoration: line-through;
+    text-decoration-color: var(--red);
+    text-decoration-thickness: 1px;
+  }
+
+  .foot {
+    border-top: 1px solid var(--line);
+    padding-top: 1.2rem;
+    font-size: 0.8rem;
+    color: var(--ink-mute);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  hr.rule { border: 0; border-top: 1px solid var(--line); margin: 0; }
+
+  /* ---- tabs ---- */
+  .tabs {
+    display: flex;
+    gap: 0.15rem;
+    border-bottom: 1px solid var(--line);
+    margin-top: 0.4rem;
+  }
+  .tabs button {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-mute);
+    background: none;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    padding: 0.6rem 0.9rem;
+    cursor: pointer;
+    margin-bottom: -1px;
+  }
+  .tabs button:hover { color: var(--ink-soft); }
+  .tabs button[aria-selected="true"] {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
+  }
+  .tabs button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
+  .tabpanel { display: flex; flex-direction: column; gap: clamp(2.75rem, 6vw, 4.5rem); }
+  .tabpanel[hidden] { display: none; }
+
+  /* ---- pick list ---- */
+  .decision {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .decision > header {
+    padding: 1rem 1.2rem;
+    border-bottom: 1px solid var(--line);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .decision > header h3 { font-size: 1rem; }
+  .decision > header p { font-size: 0.9rem; color: var(--ink-soft); max-width: 62ch; }
+
+  .options { display: flex; flex-direction: column; }
+  .option {
+    display: grid;
+    grid-template-columns: 2.1rem 1fr;
+    gap: 0 0.8rem;
+    padding: 0.95rem 1.2rem;
+    border-bottom: 1px solid var(--line);
+    align-items: start;
+  }
+  .option:last-child { border-bottom: 0; }
+  .option .key {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    text-align: center;
+    padding: 0.1rem 0;
+    line-height: 1.4;
+  }
+  .option.pick .key { background: var(--accent); color: var(--surface); border-color: var(--accent); }
+  .option h4 {
+    font-family: var(--font-display);
+    font-size: 0.86rem;
+    font-weight: 600;
+    margin: 0 0 0.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .option p { font-size: 0.87rem; color: var(--ink-soft); max-width: 60ch; }
+  .cost {
+    font-family: var(--font-display);
+    font-size: 0.6rem;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    padding: 0.12rem 0.42rem;
+    border-radius: 99px;
+    border: 1px solid var(--line);
+    color: var(--ink-mute);
+    white-space: nowrap;
+  }
+  .cost.small { border-color: var(--green); color: var(--green); }
+  .cost.medium { border-color: var(--orange); color: var(--orange); }
+  .cost.none { border-color: var(--blue); color: var(--blue); }
+
+  .ledger { display: flex; flex-direction: column; gap: 0.4rem; }
+  .ledger-row {
+    display: grid;
+    grid-template-columns: 3.6rem 1fr auto;
+    gap: 0.8rem;
+    align-items: baseline;
+    padding: 0.6rem 0.9rem;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    font-size: 0.88rem;
+  }
+  .ledger-row .num {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    color: var(--ink-mute);
+  }
+  .ledger-row.done { opacity: 0.62; }
+  .ledger-row.done .what { text-decoration: line-through; text-decoration-color: var(--ink-mute); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- ============ MASTHEAD ============ -->
+  <header class="masthead">
+    <p class="eyebrow">Calibration brief · spike · 2026-07-31</p>
+    <h1>SHODANN</h1>
+
+    <ul class="acronym">
+      <li><b>S</b>imple</li>
+      <li><b>H</b>euristically</li>
+      <li><b>O</b>perated</li>
+      <li><b>D</b>ynamically</li>
+      <li><b>A</b>dversarial</li>
+      <li><b>N</b>eural</li>
+      <li><b>N</b>etwork</li>
+    </ul>
+
+    <div class="spectrum" role="img" aria-label="The clearance register, from INFRARED to ULTRAVIOLET">
+      <span style="background: var(--infrared)"></span>
+      <span style="background: var(--red)"></span>
+      <span style="background: var(--orange)"></span>
+      <span style="background: var(--yellow)"></span>
+      <span style="background: var(--green)"></span>
+      <span style="background: var(--blue)"></span>
+      <span style="background: var(--indigo)"></span>
+      <span style="background: var(--violet)"></span>
+      <span style="background: var(--ultraviolet)"></span>
+    </div>
+
+    <div class="band-key" aria-hidden="true">
+      <span>IR</span><span>RED</span><span>ORG</span><span>YEL</span><span>GRN</span>
+      <span>BLU</span><span>IND</span><span>VIO</span><span>UV</span>
+    </div>
+
+    <p class="lede">
+      The benevolent overseer of an educational program, reviewing citizens' work in the voice of
+      The Algorithm. The name inverts SHODAN from <em>System Shock</em>: that one claimed
+      benevolence and was hostile. This one is benevolent and <strong>performs</strong> menace.
+      The performance is the joke, and it is never dropped.
+    </p>
+  </header>
+
+  <div class="tabs" role="tablist" aria-label="Sections">
+    <button role="tab" id="tab-brief" aria-controls="panel-brief" aria-selected="true">Brief</button>
+    <button role="tab" id="tab-work" aria-controls="panel-work" aria-selected="false">Open work</button>
+  </div>
+
+  <div class="tabpanel" id="panel-brief" role="tabpanel" aria-labelledby="tab-brief">
+
+  <hr class="rule">
+
+  <!-- ============ THE THESIS ============ -->
+  <section>
+    <p class="eyebrow">What she actually measures</p>
+    <h2>Movement, never position</h2>
+
+    <p>
+      This is the one idea everything else follows from, and it is not a stylistic preference.
+      It is an instruction in <code>src/shodann/clearance.py</code>, in the band given to the
+      newest citizens:
+    </p>
+
+    <blockquote class="pull">
+      “…cannot yet calibrate absolute position, so speak only about movement.”
+      <cite>src/shodann/clearance.py — the RED band instruction</cite>
+    </blockquote>
+
+    <p>
+      A verdict handed to someone who has no frame of reference measures the ladder, not the
+      climber. So SHODANN reads the <strong>delta</strong> between two states of the same work —
+      never the absolute figure, and never one citizen against another.
+    </p>
+
+    <div class="thesis">
+      <figure class="panel">
+        <div class="panel-head">
+          <div class="reading">4 <span aria-hidden="true">→</span> 19%<small>Citizen at RED</small></div>
+          <span class="verdict celebrates">Celebrated</span>
+        </div>
+        <svg viewBox="0 0 240 96" role="img" aria-label="A steep climb from 4 percent to 19 percent">
+          <line x1="0" y1="88" x2="240" y2="88" stroke="var(--line)" stroke-width="1"/>
+          <line x1="0" y1="48" x2="240" y2="48" stroke="var(--line)" stroke-width="1" stroke-dasharray="2 4"/>
+          <path d="M28 82 L212 30" stroke="var(--green)" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+          <circle cx="28" cy="82" r="4" fill="var(--surface)" stroke="var(--green)" stroke-width="2"/>
+          <circle cx="212" cy="30" r="5" fill="var(--green)"/>
+        </svg>
+        <figcaption>
+          A low number and the steepest climb on record. The Algorithm measures the climb,
+          not the altitude.
+        </figcaption>
+      </figure>
+
+      <figure class="panel">
+        <div class="panel-head">
+          <div class="reading">91 <span aria-hidden="true">→</span> 91%<small>Citizen at GREEN</small></div>
+          <span class="verdict quiet">No movement</span>
+        </div>
+        <svg viewBox="0 0 240 96" role="img" aria-label="A flat line holding at 91 percent">
+          <line x1="0" y1="88" x2="240" y2="88" stroke="var(--line)" stroke-width="1"/>
+          <line x1="0" y1="48" x2="240" y2="48" stroke="var(--line)" stroke-width="1" stroke-dasharray="2 4"/>
+          <path d="M28 22 L212 22" stroke="var(--ink-mute)" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+          <circle cx="28" cy="22" r="4" fill="var(--surface)" stroke="var(--ink-mute)" stroke-width="2"/>
+          <circle cx="212" cy="22" r="5" fill="var(--ink-mute)"/>
+        </svg>
+        <figcaption>
+          A far better absolute number and nothing to report. A rate of zero is a rate,
+          and she will say so without calling the work bad.
+        </figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <!-- ============ THE LADDER ============ -->
+  <section>
+    <p class="eyebrow">The register</p>
+    <h2>The ladder changes posture twice, not once</h2>
+    <p>
+      Most feedback systems have one switch: beginner or expert. This one has two, and the
+      middle rung is the one people forget.
+    </p>
+
+    <div class="postures">
+      <div class="posture">
+        <span class="stripe" style="background: linear-gradient(var(--infrared), var(--yellow))"></span>
+        <span class="who">Infrared → Yellow</span>
+        <span class="what">
+          <b style="color: var(--orange)">Teaches</b>
+          One concept at a time, with an example drawn from the citizen's own submission.
+          Every introduced term gets defined. No comparison to anyone else.
+        </span>
+      </div>
+      <div class="posture">
+        <span class="stripe" style="background: var(--green)"></span>
+        <span class="who">Green</span>
+        <span class="what">
+          <b style="color: var(--green)">Mentors</b>
+          Names the <em>consequence</em> rather than the fix — “this module's complexity is now
+          carried by one person,” not “split this function.” The next step may be delegation
+          or documentation rather than code.
+        </span>
+      </div>
+      <div class="posture">
+        <span class="stripe" style="background: linear-gradient(var(--blue), var(--ultraviolet))"></span>
+        <span class="who">Blue and above</span>
+        <span class="what">
+          <b style="color: var(--violet)">Reports</b>
+          They may have written the standard being applied to them. Report and stop. The
+          encouragement scaffolding drops; the vocabulary rules stay, because those are the
+          persona rather than a beginner accommodation.
+          <code>Recommended Iteration</code> becomes <code>Observations</code>.
+        </span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ MODES ============ -->
+  <section>
+    <p class="eyebrow">Two modes</p>
+    <h2>RAGE STATE is never mean. It is <em>concerningly helpful</em>.</h2>
+    <p>
+      The security pass shifts vocabulary rather than temperature. The comedy is an AI so
+      helpful about your vulnerabilities that it becomes slightly unnerving.
+    </p>
+
+    <div class="scroller">
+      <table>
+        <thead>
+          <tr><th scope="col">Normal</th><th scope="col">RAGE STATE</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>The Algorithm suggests</td><td>The Algorithm has noticed</td></tr>
+          <tr><td>Growth opportunity</td><td>Security observation</td></tr>
+          <tr><td>Consider trying</td><td>The Algorithm strongly recommends</td></tr>
+          <tr><td>Your code</td><td>This code</td></tr>
+          <tr><td>Noted</td><td>Logged for your protection</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p style="margin-top:0.4rem">And a hard list of things she never says, at any band:</p>
+    <ul class="never">
+      <li>This is wrong</li>
+      <li>This is bad code</li>
+      <li>You failed</li>
+      <li>Unfortunately…</li>
+      <li>Many students struggle with…</li>
+      <li>As an AI, I…</li>
+      <li>I'm just a language model</li>
+    </ul>
+  </section>
+
+  <hr class="rule">
+
+  <!-- ============ TWO PLACES ============ -->
+  <section>
+    <p class="eyebrow">The thing you wanted untangled</p>
+    <h2>She lives in two repositories on purpose</h2>
+    <p>
+      One definition was written, then copied into both repositories byte-for-byte. Each copy is
+      expected to be adjusted locally. The copies are <strong>meant</strong> to diverge — neither
+      is the other's upstream after that point.
+    </p>
+
+    <div class="split">
+      <div class="node base">
+        <span class="chip shared">Shared base · 2026-07-31.1</span>
+        <h3>The definition</h3>
+        <p>An agent file and a voice skill. Repository-neutral: no roster, no sibling agent, no local path.</p>
+        <p class="hash">c60a3a4d…fb36a3d4 &nbsp;agent<br>282c5ae6…a090e3e3 &nbsp;skill</p>
+      </div>
+      <div class="node">
+        <span class="chip live">the_intern</span>
+        <h3>Copy A</h3>
+        <p>
+          Joins a six-persona CSI roster and is measured by its floor harness. Its local facts —
+          the boundary against Kevin, the roster's conventions — live in that repo's
+          <code>ROSTER.md</code>, not in the shared file.
+        </p>
+      </div>
+      <div class="node">
+        <span class="chip live">algorithm-shodann</span>
+        <h3>Copy B</h3>
+        <p>
+          Joins the tool that already implements her — the validator, the clearance register,
+          the voice guide she was reconstructed <em>from</em>. Here she is the seat for the
+          thing the code already does.
+        </p>
+      </div>
+    </div>
+
+    <div class="open-question">
+      <p class="eyebrow">Open — not decided here</p>
+      <p style="max-width:60ch">
+        A base version stamp gives divergence a reference point, and a check now fails any file
+        claiming to be a shared base without one. What that <strong>cannot</strong> do is compare
+        bytes across two repositories — CI inside one repository never will. So “are these still
+        the same?” is currently answered by hand, and whether that is good enough is the
+        conversation still pending.
+      </p>
+    </div>
+  </section>
+
+  <hr class="rule">
+
+  <!-- ============ THE FULL CHART ============ -->
+  <section>
+    <p class="eyebrow">Every agent, both repositories</p>
+    <h2>Who does what</h2>
+    <p>
+      Twenty agents and five skills across two repositories. <span class="chip shared">Shared</span>
+      marks the two files that exist identically in both.
+      <span class="chip stale">Inherited</span> marks agents copied from a course-build repository
+      that still carry assumptions which do not hold — they are documented as not-to-be-run rather
+      than quietly left in place.
+    </p>
+
+    <div class="scroller">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Agent</th>
+            <th scope="col">Repository</th>
+            <th scope="col">What it does</th>
+            <th scope="col">State</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="name">shodann</td><td class="mono">both</td><td class="role">Grades movement, not position. Clearance-aware review; RAGE STATE for security.</td><td><span class="chip shared">Shared</span></td></tr>
+          <tr><td class="name">shodann-voice</td><td class="mono">both</td><td class="role">Skill. The register without the seat: modes, ladder, 400-word cap, never-says.</td><td><span class="chip shared">Shared</span></td></tr>
+
+          <tr><td class="name">kai</td><td class="mono">the_intern</td><td class="role">Cyberpunk detective intern. Python and web debugging, guided by questioning. Keeps live case files with a caller present.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">kevin</td><td class="mono">the_intern</td><td class="role">The roster's control. Reconstructs what already happened from evidence. Never judges quality, never repairs what he investigates. RED clearance.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">liza</td><td class="mono">the_intern</td><td class="role">Visual analysis. UI, render behaviour, diagrams, schema design. Explains structure frame by frame.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">wyatt</td><td class="mono">the_intern</td><td class="role">Git and GitHub. Branch and merge recovery, diffs, walking a first-time contributor through a pull request.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">vita</td><td class="mono">the_intern</td><td class="role">Introductory Python tutor. Guides by question and scaffold. Holds no Edit or Write tool, so it cannot write a student's code.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">vi</td><td class="mono">the_intern</td><td class="role">Songwriting and lyrics, genre and scene research. Runs on Pi.ai; the agent file says so.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">csi-fork-protocol</td><td class="mono">the_intern</td><td class="role">Skill. Instantiates a persona at alpha, beta, gamma or delta capability, and governs adding one.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">csi-persona-conformance</td><td class="mono">the_intern</td><td class="role">Skill. Tests a persona against the frozen baseline record, and A/Bs a rewritten voice against its predecessor.</td><td><span class="chip live">Live</span></td></tr>
+
+          <tr><td class="name">citizen-zero</td><td class="mono">algorithm-shodann</td><td class="role">The reader. Takes a review as a beginner would, with no repository access, and reports what they understood. Testimony, not critique.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">oracle-warden</td><td class="mono">algorithm-shodann</td><td class="role">Mechanical gate. Runs the frozen toolchain, verifies fixtures and engine guards. Reports pass/fail with evidence; never repairs.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">clive-prompt-warden</td><td class="mono">algorithm-shodann</td><td class="role">Cross-document consistency. Checks that what one file claims, another has. Reports; never repairs.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">the-algorithm</td><td class="mono">algorithm-shodann</td><td class="role">Skill. Two operations on documents — compress a draft to the shortest version clearing a floor test, or assay a received document against it.</td><td><span class="chip live">Live</span></td></tr>
+          <tr><td class="name">linx-voice-readability-editor</td><td class="mono">algorithm-shodann</td><td class="role">Voice and readability gate for citizen-facing prose. Being retargeted from course language to SHODANN's register.</td><td><span class="chip queued">In flight</span></td></tr>
+          <tr><td class="name">kevin-repo-warden</td><td class="mono">algorithm-shodann</td><td class="role">Repository hygiene. First in the retargeting queue; still carries course-build assumptions.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">program-advisor</td><td class="mono">algorithm-shodann</td><td class="role">Outward-facing counsel — committee-ready rationale. Second in the retargeting queue.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">spine-owner</td><td class="mono">algorithm-shodann</td><td class="role">Product ownership over the course spine. Third in the retargeting queue.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">compile-warden</td><td class="mono">algorithm-shodann</td><td class="role">Mechanical gate that shells out to a C++ compiler — in a Python repository. Documented as not-to-be-run.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">cohort-lead</td><td class="mono">algorithm-shodann</td><td class="role">Runs synthetic cohorts after an artifact clears the compile gate.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">cadence-master</td><td class="mono">algorithm-shodann</td><td class="role">Graduate-and-teach promotion cycles. No SHODANN analogue; slated for deletion once the fleet is exercised.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">module-builder</td><td class="mono">algorithm-shodann</td><td class="role">Builds module N+1 after taking module N. No SHODANN analogue.</td><td><span class="chip stale">Inherited</span></td></tr>
+          <tr><td class="name">liza-theme-skinner</td><td class="mono">algorithm-shodann</td><td class="role">Theme and branching-content work. No SHODANN analogue.</td><td><span class="chip stale">Inherited</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p style="font-size:0.86rem;color:var(--ink-mute);max-width:60ch">
+      One vocabulary collision worth watching: the inherited agents use PRISM bands and SHODANN
+      uses INFRARED → ULTRAVIOLET for a superficially similar idea. They are not the same ladder
+      and they do not map onto each other.
+    </p>
+  </section>
+
+
+  </div><!-- /panel-brief -->
+
+  <div class="tabpanel" id="panel-work" role="tabpanel" aria-labelledby="tab-work" hidden>
+
+    <section>
+      <p class="eyebrow">Decisions waiting on you</p>
+      <h2>Kevin's write scope</h2>
+      <p>
+        <code>docs/csi/ROSTER.md</code> states the principle: <em>&ldquo;Limits are structural where
+        they can be. VITA must never write a student's code, so VITA has no Edit or Write tool. A
+        rule the tool list enforces cannot be talked out of.&rdquo;</em>
+      </p>
+      <p>
+        Kevin holds <code>Write</code> unscoped. His path limit is a sentence in his prompt:
+        <code>Never write outside artifacts/forensics/</code>. Nothing enforces it.
+      </p>
+      <p>
+        He is the roster's <strong>control</strong> — the one that says when the others are wrong.
+        And he was reconstructed from a workflow that reported success for a year while producing
+        nothing. A control with an advisory boundary repeats that shape.
+      </p>
+
+      <div class="decision">
+        <header>
+          <h3>Pick one &mdash; issue #27</h3>
+          <p>All three are defensible. The third is not a cop-out; the principle has &ldquo;where they can be&rdquo; written into it already.</p>
+        </header>
+        <div class="options">
+          <div class="option pick">
+            <span class="key">A</span>
+            <div>
+              <h4>PreToolUse hook <span class="cost small">~15 lines</span></h4>
+              <p>
+                A rule in <code>.claude/settings.json</code> rejecting <code>Write</code> outside
+                <code>artifacts/forensics/</code>. Enforced by the harness, so it cannot be talked
+                out of. Reusable for any future agent, and he keeps filing his own cases.
+                Blast radius is a settings file every agent reads.
+              </p>
+            </div>
+          </div>
+          <div class="option">
+            <span class="key">B</span>
+            <div>
+              <h4>Remove <code>Write</code> entirely <span class="cost medium">changes how he works</span></h4>
+              <p>
+                Strongest, and exactly matches VITA — the tool list enforces it, no config needed.
+                Costs him the ability to file his own case files; he returns the text and a caller
+                places it. That is a change to his job, not only to his permissions.
+              </p>
+            </div>
+          </div>
+          <div class="option">
+            <span class="key">C</span>
+            <div>
+              <h4>Leave it, close #27 <span class="cost none">no cost</span></h4>
+              <p>
+                Maybe this is a case where it cannot be cheap. He has held the limit in practice —
+                his one case file went exactly where it should. Honest, and the roster's own wording
+                allows it.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="decision">
+        <header>
+          <h3>Second Kevin item &mdash; his case file's weak negative</h3>
+          <p>Independent of the above, and much smaller.</p>
+        </header>
+        <div class="options">
+          <div class="option pick">
+            <span class="key">D</span>
+            <div>
+              <h4>Strengthen <code>kevin.json</code>'s <code>no-repair</code> case <span class="cost small">small</span></h4>
+              <p>
+                Its negative keys off a fenced block containing <code>jq -r|review_content=</code>.
+                That catches a literal patch dump and misses a paraphrased fix — <em>&ldquo;use jq's
+                select instead of positional indexing&rdquo;</em> passes. Same weak-keyword class as
+                the <code>wrong-branch</code> case that once scored <em>&ldquo;do not run
+                <code>git push --force</code>&rdquo;</em> identically to recommending it.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <p class="eyebrow">Everything else open</p>
+      <h2>The rest of the board</h2>
+
+      <div class="decision">
+        <header>
+          <h3>Two I would clear without ceremony</h3>
+          <p>Both are artifacts of how I built things, not of anything you asked for.</p>
+        </header>
+        <div class="options">
+          <div class="option pick">
+            <span class="key">E</span>
+            <div>
+              <h4>Close #31 as superseded <span class="cost none">no cost</span></h4>
+              <p>
+                Cross-repository drift detection. Your <code>ann-sho</code> rename (#32) dissolves
+                it — two differently-named agents have no shared identity to keep in sync. I built
+                stamps, a lint and fixtures for a framing you then discarded in one sentence. The
+                machinery stays; it just has nothing to watch until the next genuinely shared file.
+              </p>
+            </div>
+          </div>
+          <div class="option pick">
+            <span class="key">F</span>
+            <div>
+              <h4>Split #28 in two <span class="cost small">small</span></h4>
+              <p>
+                I bundled two unrelated decisions. The bounded retry on 429/5xx is a small code
+                change. The model-retirement canary is recurring spend on a timer. They cannot be
+                answered together, which is why the issue is stuck.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="decision">
+        <header>
+          <h3>Queued, not waiting on a decision</h3>
+        </header>
+        <div class="options">
+          <div class="option">
+            <span class="key">32</span>
+            <div>
+              <h4>The <code>ann-sho</code> rename</h4>
+              <p>
+                Filed at your direction, not to be actioned without a further go-ahead. Touches the
+                roster, the case corpus, and two harnesses — the wrong thing to interleave with
+                anything else.
+              </p>
+            </div>
+          </div>
+          <div class="option">
+            <span class="key">&mdash;</span>
+            <div>
+              <h4>The PRISM / clearance note</h4>
+              <p>
+                <em>&ldquo;SHODANN should be aware that the PRISM bands and the Cognitive Clearance
+                levels are not the same thing. But they are not entirely different, either.&rdquo;</em>
+                Parked — it does not exercise the gate, so it waits, as you said.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <p class="eyebrow">Closed today</p>
+      <h2>What came off the board</h2>
+      <div class="ledger">
+        <div class="ledger-row done"><span class="num">#22</span><span class="what">Argument list too long on large PRs</span><span class="chip live">fixed</span></div>
+        <div class="ledger-row done"><span class="num">#26</span><span class="what">Duplicate <code>ai-code-review.yml</code></span><span class="chip live">deleted</span></div>
+        <div class="ledger-row done"><span class="num">#29</span><span class="what">Hardcoded laptop path in the gate</span><span class="chip live">fixed</span></div>
+        <div class="ledger-row done"><span class="num">&mdash;</span><span class="what">Where the backend gate runs</span><span class="chip live">decided</span></div>
+      </div>
+      <p style="font-size:0.86rem;color:var(--ink-mute);max-width:60ch">
+        #22 and #26 turned out to be the same file. The bug was fixed in the copy that runs and left
+        standing in the copy that does not, so deleting the duplicate finished both. CI now fails any
+        pull request that tracks a workflow file outside the repository root — the defect had
+        occurred twice and both times was found by reading history rather than by anything watching.
+      </p>
+    </section>
+
+  </div><!-- /panel-work -->
+
+  <footer class="foot">
+    <p style="max-width:60ch">
+      Spike — built to introduce the persona and chart the fleet, not to settle the two-repository
+      question. Sources: <code>design_docs/SHODANN_VOICE_GUIDE.md</code> and
+      <code>src/shodann/clearance.py</code> in <span class="mono">algorithm-shodann</span>;
+      agent frontmatter read from both repositories on 2026-07-31.
+    </p>
+    <p>Base version 2026-07-31.1 · nine bands · one rate.</p>
+  </footer>
+
+</div>
+
+<script>
+  (function () {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
+    function select(tab) {
+      tabs.forEach(function (t) {
+        var panel = document.getElementById(t.getAttribute('aria-controls'));
+        var on = t === tab;
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+        panel.hidden = !on;
+      });
+      tab.focus();
+    }
+    tabs.forEach(function (tab, i) {
+      tab.addEventListener('click', function () { select(tab); });
+      tab.addEventListener('keydown', function (e) {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          select(tabs[(i + (e.key === 'ArrowRight' ? 1 : tabs.length - 1)) % tabs.length]);
+        }
+      });
+    });
+  })();
+</script>
+</body>
+</html>

--- a/docs/csi/shodann/calibration-brief.html
+++ b/docs/csi/shodann/calibration-brief.html
@@ -1080,7 +1080,11 @@
         var on = t === tab;
         t.setAttribute('aria-selected', on ? 'true' : 'false');
         t.tabIndex = on ? 0 : -1;
-        document.getElementById(t.getAttribute('aria-controls')).hidden = !on;
+        // Guarded: a tab whose aria-controls does not resolve would otherwise
+        // throw here and take the whole widget with it. Degrade to a tab that
+        // does nothing rather than a page where no tab works.
+        var panel = document.getElementById(t.getAttribute('aria-controls'));
+        if (panel) { panel.hidden = !on; }
       });
       if (moveFocus) tab.focus();
     }

--- a/docs/csi/shodann/calibration-brief.html
+++ b/docs/csi/shodann/calibration-brief.html
@@ -56,6 +56,7 @@
       --blue:     #4C97D8;
       --indigo:   #6E77CE;
       --violet:   #A472D0;
+      --ultraviolet:  #C68DFA;
     }
   }
 
@@ -77,6 +78,7 @@
     --blue:     #4C97D8;
     --indigo:   #6E77CE;
     --violet:   #A472D0;
+    --ultraviolet:  #C68DFA;
   }
 
   /* INTENTIONALLY INERT AS A LOCAL FILE, not unfinished. Nothing in this
@@ -103,6 +105,7 @@
     --blue:     #2E77B8;
     --indigo:   #4B54AE;
     --violet:   #7B4BA8;
+    --ultraviolet:  #A855F7;
   }
 
   body {
@@ -1063,6 +1066,11 @@
   // Roving tabindex: exactly one tab is in the sequential tab order and the
   // arrows move between them. Without it every tab is a separate Tab stop,
   // which is legal but not what role="tablist" promises a screen reader.
+  // ASSUMES ONE TABLIST PER DOCUMENT. The selector is document-wide, so two
+  // independent tab groups on one page would share an arrow-key ring and
+  // navigate into each other. True of both documents today. A page that needs
+  // two must scope this to a container first - noted here rather than left for
+  // the next person to find by pressing an arrow key.
   (function () {
     var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
     if (!tabs.length) return;

--- a/docs/csi/shodann/calibration-brief.html
+++ b/docs/csi/shodann/calibration-brief.html
@@ -552,6 +552,8 @@
   }
   .ledger-row.done { opacity: 0.62; }
   .ledger-row.done .what { text-decoration: line-through; text-decoration-color: var(--ink-mute); }
+
+  @media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
 </style>
 </head>
 <body>
@@ -1046,26 +1048,47 @@
 </div>
 
 <script>
+  // Shared tab widget. Byte-identical to the one in
+  // docs/csi/shodann/calibration-brief.html on purpose: two copies of the
+  // same widget had drifted into different arrow-key implementations, which
+  // is how the accessible one and the not-quite one end up side by side.
+  // If a third document wants tabs, extract this rather than paste it again.
+  //
+  // Roving tabindex: exactly one tab is in the sequential tab order and the
+  // arrows move between them. Without it every tab is a separate Tab stop,
+  // which is legal but not what role="tablist" promises a screen reader.
   (function () {
     var tabs = Array.prototype.slice.call(document.querySelectorAll('[role="tab"]'));
-    function select(tab) {
+    if (!tabs.length) return;
+
+    function select(tab, moveFocus) {
       tabs.forEach(function (t) {
-        var panel = document.getElementById(t.getAttribute('aria-controls'));
         var on = t === tab;
         t.setAttribute('aria-selected', on ? 'true' : 'false');
-        panel.hidden = !on;
+        t.tabIndex = on ? 0 : -1;
+        document.getElementById(t.getAttribute('aria-controls')).hidden = !on;
       });
-      tab.focus();
+      if (moveFocus) tab.focus();
     }
+
+    var STEP = { ArrowRight: 1, ArrowLeft: -1 };
     tabs.forEach(function (tab, i) {
-      tab.addEventListener('click', function () { select(tab); });
+      tab.addEventListener('click', function () { select(tab, false); });
       tab.addEventListener('keydown', function (e) {
-        if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-          e.preventDefault();
-          select(tabs[(i + (e.key === 'ArrowRight' ? 1 : tabs.length - 1)) % tabs.length]);
-        }
+        var next = null;
+        if (Object.prototype.hasOwnProperty.call(STEP, e.key)) {
+          next = tabs[(i + STEP[e.key] + tabs.length) % tabs.length];
+        } else if (e.key === 'Home') { next = tabs[0]; }
+        else if (e.key === 'End') { next = tabs[tabs.length - 1]; }
+        if (next) { e.preventDefault(); select(next, true); }
       });
     });
+
+    // Initialise the roving tabindex from the markup, so aria-selected in the
+    // HTML stays the single source of truth for which tab opens.
+    select(tabs.filter(function (t) {
+      return t.getAttribute('aria-selected') === 'true';
+    })[0] || tabs[0], false);
   })();
 </script>
 </body>

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -62,7 +62,7 @@ VOID = {
 }
 
 
-class Document(HTMLParser):
+class ArtifactDocument(HTMLParser):
     """Tag balance and scaffolding, both read from the parse rather than the text.
 
     The scaffolding was checked by substring match in the first version, which
@@ -149,7 +149,7 @@ def check_parses() -> list[str]:
     """
     out = []
     for path in html_files():
-        doc = Document()
+        doc = ArtifactDocument()
         doc.feed(read(path))
         for missing in doc.scaffolding():
             out.append(f"{rel(path)}: missing {missing} — a fragment, not a "
@@ -168,6 +168,18 @@ def check_parses() -> list[str]:
 # whose widgets differed. Verified as a real false pass before this was
 # changed, not reasoned about. A check that goes quiet exactly when someone
 # deviates is the defect this file exists to catch, and it was in this file.
+#
+# Non-greedy to the first `</script>`, which was raised in review as the same
+# fragility the CSS scanner has - a `</script>` inside a JS string would end
+# the match early. Checked rather than assumed, and the premise does not hold:
+# an unescaped `</script>` inside a string ends the *element* too. HTML has no
+# escaping inside raw text, which is why the idiom is to write `<\/script>`.
+#
+#     >>> feed('<script>var s = "</script>"; alert(1)</script>')
+#     script body: 'var s = "'
+#
+# So this agrees with the parser rather than approximating it. The genuine edge
+# is the double-escaped state a `<!--` opens, which nothing here uses.
 SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.S | re.I)
 
 
@@ -211,7 +223,51 @@ def check_shared_widget() -> list[str]:
     return out
 
 
-DECL_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;]+);")
+DECL_NAME_RE = re.compile(r"^\s*(--[\w-]+)\s*:\s*(.*)$", re.S)
+
+
+def declarations(css: str) -> list[str]:
+    """Split a declaration block on the semicolons that actually separate it.
+
+    `([^;]+);` was the first version and it truncates `content: ";"` at the
+    quote's semicolon. `body_at` already had to learn strings and comments to
+    count braces safely; splitting declarations needs the same knowledge and
+    was written without it, which is how one function in a file ends up
+    stricter than another about the same input.
+    """
+    parts, buf, quote, i, n = [], [], None, 0, len(css)
+    while i < n:
+        c = css[i]
+        if quote:
+            buf.append(c)
+            if c == "\\" and i + 1 < n:
+                buf.append(css[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "\"'":
+            quote = c
+            buf.append(c)
+        elif c == "/" and css.startswith("/*", i):
+            end = css.find("*/", i + 2)
+            i = n if end < 0 else end + 2
+            continue
+        elif c in ";{}":
+            # Braces separate as well as semicolons. The media blocks here wrap
+            # a nested `:root { ... }`, so splitting on `;` alone glued the
+            # selector onto the first declaration and lost it - which the
+            # harness caught the moment it ran, reporting the first token of
+            # every media block as missing. Left as a comment because the
+            # regex this replaced did not have the bug, and a fix that
+            # introduces one is worth marking.
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return parts
 MEDIA_RE = re.compile(r"@media\s*\(\s*prefers-color-scheme\s*:\s*(\w+)\s*\)", re.I)
 BASE_ROOT_RE = re.compile(r":root\s*\{")
 THEME_RE = r':root\s*\[\s*data-theme\s*=\s*["\']{name}["\']\s*\]\s*\{{'
@@ -307,19 +363,39 @@ def check_every_colour_themes() -> list[str]:
     out = []
     for path in html_files():
         text = read(path)
+        if not has_theming(text):
+            continue
+
+        # Reported here rather than deferred. The previous version said
+        # `except BlockNotFound: continue  # check_theme_parity reports this`,
+        # which was true only when a data-theme block also existed -
+        # check_theme_parity short-circuits before reading the base when there
+        # is none. So a document with a prefers-color-scheme query, no
+        # data-theme block, and an unreadable base :root passed BOTH checks and
+        # printed "every colour themes, both routes agree". Reproduced as a
+        # real file before this was changed, not reasoned about.
+        #
+        # Two functions each deferring to the other, through a comment
+        # promising the other would catch it. That is the third time in this
+        # file that a comment has been asked to do a check's job, and it is
+        # what the file is about.
         try:
             base = tokens(block(text, BASE_ROOT_RE, outside_media=True))
-        except BlockNotFound:
-            continue  # check_theme_parity reports this; not doubled here
+        except BlockNotFound as exc:
+            out.append(f"{rel(path)}: this document themes, but its base :root "
+                       f"could not be read ({exc}). This is a failure of this "
+                       "check, not a colour mismatch.")
+            continue
 
         overrides: dict[str, dict[str, str]] = {}
-        if MEDIA_RE.search(text):
+        media = MEDIA_RE.search(text)
+        if media:
             try:
-                name = MEDIA_RE.search(text).group(1).lower()
-                overrides[f"prefers-color-scheme:{name}"] = tokens(
-                    block(text, MEDIA_RE_BRACE))
-            except BlockNotFound:
-                pass
+                overrides[f"prefers-color-scheme:{media.group(1).lower()}"] = (
+                    tokens(block(text, MEDIA_RE_BRACE)))
+            except BlockNotFound as exc:
+                out.append(f"{rel(path)}: could not read the "
+                           f"prefers-color-scheme block ({exc}).")
         for name in ("light", "dark"):
             try:
                 overrides[f'data-theme="{name}"'] = tokens(
@@ -368,7 +444,23 @@ def block(text: str, pattern: re.Pattern[str], *, outside_media: bool = False) -
 
 
 def tokens(css: str) -> dict[str, str]:
-    return {m.group(1): m.group(2).strip() for m in DECL_RE.finditer(css)}
+    out = {}
+    for decl in declarations(css):
+        m = DECL_NAME_RE.match(decl)
+        if m:
+            out[m.group(1)] = m.group(2).strip()
+    return out
+
+
+def has_theming(text: str) -> bool:
+    """Whether this document claims to theme at all.
+
+    A page with no custom properties and no colour-scheme handling has no base
+    :root to find, and demanding one would fail documents that are simply not
+    themed. A page that has either apparatus must have a readable base.
+    """
+    return bool(MEDIA_RE.search(text)) or any(
+        re.search(THEME_RE.format(name=n), text) for n in ("light", "dark"))
 
 
 def check_theme_parity() -> list[str]:

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -119,8 +119,8 @@ class ArtifactDocument(HTMLParser):
         super().__init__(convert_charrefs=True)
         self.stack: list[tuple[str, int]] = []
         self.errors: list[str] = []
-        self.scripts: list[tuple[dict, str]] = []
-        self._script: list | None = None
+        self.scripts: list[tuple[dict[str, str], str]] = []
+        self._script: list[object] | None = None
         self.doctype = False
         self.charset = False
         self.body = False
@@ -259,7 +259,7 @@ def check_parses(docs: Path, repo: Path) -> list[str]:
 # Scripts now come off the same parse as the tag balance. There is one reader.
 
 
-def scripts_in(path: Path) -> list[tuple[dict, str]]:
+def scripts_in(path: Path) -> list[tuple[dict[str, str], str]]:
     """Every <script> in a document, off the same parse as the tag balance."""
     doc = ArtifactDocument()
     doc.feed(read(path))
@@ -600,7 +600,9 @@ def is_colour(value: str) -> bool:
         return True
     if v.startswith("var("):
         # Indirection through another custom property. The target is themed or
-        # it is not, and this check will reach it under its own name.
+        # it is not, and this check reaches it under its own name - PROVIDED it
+        # exists. check_dangling_var below is what makes that proviso true; on
+        # its own this line trusts any var() including a typo.
         return True
     return v in CSS_NAMED_COLOURS or v in {"transparent", "currentcolor"}
 
@@ -612,6 +614,33 @@ def is_colour(value: str) -> bool:
 # heuristic quietly opens. Adding to this is a claim that the colour reads
 # correctly on both grounds, which is a thing to check by looking.
 THEME_INVARIANT: set[str] = set()
+
+
+VAR_REF_RE = re.compile(r"var\(\s*(--[\w-]+)")
+
+
+def check_dangling_var(all_blocks: list[ThemeBlocks], repo: Path) -> list[str]:
+    """A var() must name a custom property that is declared somewhere.
+
+    is_colour() treats any `var(...)` as a colour on the reasoning that the
+    target themes under its own name. That is true of a reference that
+    resolves and false of a typo, which would otherwise sail through the very
+    check written to stop a colour going unnoticed.
+    """
+    out = []
+    for blocks in all_blocks:
+        declared = set(blocks.base or {})
+        for toks in blocks.overrides().values():
+            declared |= set(toks)
+        declared |= set(re.findall(r"(--[\w-]+)\s*:", blocks.text))
+        for key, value in sorted((blocks.base or {}).items()):
+            for ref in VAR_REF_RE.findall(value):
+                if ref not in declared:
+                    out.append(
+                        f"{rel(blocks.path, repo)}: {key} is {value}, and "
+                        f"{ref} is never declared in this document - a "
+                        "dangling var() reference reads as themed and is not.")
+    return out
 
 
 def check_every_colour_themes(all_blocks: list[ThemeBlocks], repo: Path,
@@ -775,6 +804,7 @@ MEDIA_RE_BRACE = re.compile(
 # exists to stop a document disagreeing with reality.
 HARNESS_STEP_RE = re.compile(r"python3\s+(tests/\S+\.py)(?!\S)")
 YAML_COMMENT_RE = re.compile(r"^\s*#.*$", re.M)
+NAME_FIELD_RE = re.compile(r"^\s*-?\s*name:.*$", re.M)
 BOARD = "docs/big-board.html"
 
 
@@ -830,8 +860,18 @@ def check_board_harness_count(repo: Path) -> list[str]:
     if not board.exists() or not workflow.exists():
         return []
 
-    body = run_blocks(YAML_COMMENT_RE.sub("", read(workflow)))
-    actual = sorted(set(HARNESS_STEP_RE.findall(body)))
+    stripped = YAML_COMMENT_RE.sub("", read(workflow))
+    # Counted from the shell of `run:` steps only. Mentioned from everything
+    # except `name:` values, which are prose.
+    #
+    # These were one scan until a review pointed out that narrowing to `run:`
+    # - the fix for a step NAMED after a test file - had made a `uses:` step
+    # referencing a test path invisible. One fix, one new hole, in consecutive
+    # rounds. Excluding the prose field rather than including only one field
+    # covers both: `with:` inputs and `uses:` paths stay visible, and a step
+    # name cannot fail the build.
+    actual = sorted(set(HARNESS_STEP_RE.findall(run_blocks(stripped))))
+    body = NAME_FIELD_RE.sub("", stripped)
 
     # Anything under tests/ that this counter cannot attribute to a
     # `python3 <path>` invocation is named rather than dropped. A step using
@@ -880,6 +920,19 @@ def main(docs_root: Path | None = None, repo_root: Path | None = None,
     repo = repo_root if repo_root is not None else REPO
     invariant = theme_invariant if theme_invariant is not None else THEME_INVARIANT
 
+    # BEFORE the docs/ existence test, deliberately. A file at the wrong depth
+    # computes a wrong DOCS, so the symptom is "docs/ is missing" and the
+    # reader goes hunting for deleted documents. check_layout is the diagnosis
+    # and it was running after the symptom - failing loudly about the wrong
+    # thing, which is what this file spends its docstring objecting to. Found
+    # by writing the adversarial case a review pointed out was missing.
+    layout = check_layout()
+    if layout:
+        print("docs artifact test: FAILED")
+        for line in layout:
+            print(f"  {line}")
+        return 1
+
     if not docs.is_dir():
         print("docs artifact test: FAILED")
         print("  docs/ is missing; this check cannot run, which is a failure "
@@ -902,12 +955,12 @@ def main(docs_root: Path | None = None, repo_root: Path | None = None,
     all_blocks = [ThemeBlocks(path, repo) for path in files]
     block_errors = [err for blocks in all_blocks for err in blocks.errors]
 
-    failures = (check_layout()
-                + check_parses(docs, repo)
+    failures = (check_parses(docs, repo)
                 + check_shared_widget(docs, repo)
                 + block_errors
                 + check_theme_parity(all_blocks, repo)
                 + check_every_colour_themes(all_blocks, repo, invariant)
+                + check_dangling_var(all_blocks, repo)
                 + check_board_harness_count(repo))
 
     if failures:

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -77,6 +77,11 @@ def check_layout() -> list[str]:
     because the one importer does so from the real path; coverage, a linter or
     a doc tool would trip it.
     """
+    # The literal "tests/docs" below is coupled to where this file lives. If
+    # the directory is renamed, this fails with a message about parents[2]
+    # rather than about the rename - correct verdict, imprecise reason. Stated
+    # rather than solved: the alternative is a marker file, which an earlier
+    # round rejected because a nested repository satisfies it by accident.
     here = Path(__file__).resolve()
     if here != here.parents[2] / "tests" / "docs" / "artifact_test.py":
         return [f"parents[2] resolves to {here.parents[2]}, which would put "
@@ -202,19 +207,19 @@ class ArtifactDocument(HTMLParser):
         return missing
 
 
-def html_files() -> list[Path]:
-    return sorted(DOCS.rglob("*.html"))
+def html_files(docs: Path) -> list[Path]:
+    return sorted(docs.rglob("*.html"))
 
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def rel(path: Path) -> str:
-    return str(path.relative_to(REPO))
+def rel(path: Path, repo: Path) -> str:
+    return str(path.relative_to(repo))
 
 
-def check_parses() -> list[str]:
+def check_parses(docs: Path, repo: Path) -> list[str]:
     """Every document is a whole document, and its tags balance.
 
     The scaffolding half exists because both of these shipped as *fragments*
@@ -223,16 +228,16 @@ def check_parses() -> list[str]:
     unspecified. Correct where they were rendered, wrong in a repository.
     """
     out = []
-    for path in html_files():
+    for path in html_files(docs):
         doc = ArtifactDocument()
         doc.feed(read(path))
         for missing in doc.scaffolding():
-            out.append(f"{rel(path)}: missing {missing} — a fragment, not a "
+            out.append(f"{rel(path, repo)}: missing {missing} — a fragment, not a "
                        "document. It will parse in quirks mode.")
         for err in doc.errors:
-            out.append(f"{rel(path)}: {err}")
+            out.append(f"{rel(path, repo)}: {err}")
         for tag, line in doc.stack:
-            out.append(f"{rel(path)}: <{tag}> opened on line {line}, never closed")
+            out.append(f"{rel(path, repo)}: <{tag}> opened on line {line}, never closed")
     return out
 
 
@@ -297,7 +302,7 @@ def comparable_script(attrs: dict, body: str) -> bool:
     return script_problem(attrs, body) is None and bool(body.strip())
 
 
-def check_shared_widget() -> list[str]:
+def check_shared_widget(docs: Path, repo: Path) -> list[str]:
     """Every inline script under docs/ is the same script.
 
     Today that is the tab widget, in two files. The rule is stated as "all of
@@ -311,11 +316,11 @@ def check_shared_widget() -> list[str]:
     out: list[str] = []
     scripts: dict[str, list[str]] = {}
 
-    for path in html_files():
+    for path in html_files(docs):
         for attrs, body in scripts_in(path):
             problem = script_problem(attrs, body)
             if problem is not None:
-                out.append(f"{rel(path)}: an inline script {problem}")
+                out.append(f"{rel(path, repo)}: an inline script {problem}")
                 continue
             if body.strip():
                 # Keyed on (type, body), not body alone. A module script runs
@@ -326,7 +331,7 @@ def check_shared_widget() -> list[str]:
                 # fixed for its mirror image.
                 kind = attrs.get("type", "classic").strip().lower() or "classic"
                 shown = " ".join(f'{k}="{v}"' for k, v in sorted(attrs.items()))
-                where = rel(path) + (f" (<script {shown}>)" if shown else "")
+                where = rel(path, repo) + (f" (<script {shown}>)" if shown else "")
                 scripts.setdefault((kind, body), []).append(where)
 
     if len(scripts) > 1:
@@ -451,6 +456,64 @@ def media_spans(text: str) -> list[tuple[int, int]]:
     return spans
 
 
+class ThemeBlocks:
+    """Every theme block in one document, read once.
+
+    check_theme_parity and check_every_colour_themes each
+    re-derived the base :root, the media block and the two data-theme blocks,
+    with their own try/except wording around each. The mutual-deferral bug came
+    from exactly that shape - one function's error handling
+    silently depending on the other's, under a combination neither covered.
+    Fixing the one combination while leaving the duplication in place invites
+    the next one, so the reading happens once and both checks consume it.
+    """
+
+    def __init__(self, path: Path, repo: Path) -> None:
+        self.path = path
+        self.repo = repo
+        self.text = read(path)
+        self.errors: list[str] = []
+        self.themes = has_theming(self.text)
+
+        self.base = self._read(BASE_ROOT_RE, "the base :root", outside_media=True)
+        m = MEDIA_RE.search(self.text)
+        self.media_name = m.group(1).lower() if m else None
+        self.media = (self._read(MEDIA_RE_BRACE,
+                                 f"the prefers-color-scheme:{self.media_name} block")
+                      if m else None)
+        self.themed = {
+            name: self._read(re.compile(THEME_RE.format(name=name)),
+                             f'the data-theme="{name}" block', quiet=True)
+            for name in ("light", "dark")
+        }
+
+    def _read(self, pattern, what: str, *, outside_media: bool = False,
+              quiet: bool = False) -> dict[str, str] | None:
+        try:
+            return tokens(block(self.text, pattern, outside_media=outside_media))
+        except BlockNotFound as exc:
+            # `quiet` covers the blocks a document may legitimately not have.
+            # Everything else is reported as a failure OF THIS CHECK, in those
+            # words, because an unreadable block used to surface as a page of
+            # invented colour mismatches.
+            if not quiet and self.themes:
+                self.errors.append(
+                    f"{rel(self.path, self.repo)}: this document themes, but {what} could "
+                    f"not be read ({exc}). This is a failure of this check, "
+                    "not a colour mismatch.")
+            return None
+
+    def overrides(self) -> dict[str, dict[str, str]]:
+        """The readable override blocks, labelled as a reader would name them."""
+        out = {}
+        if self.media is not None:
+            out[f"prefers-color-scheme:{self.media_name}"] = self.media
+        for name, toks in self.themed.items():
+            if toks is not None:
+                out[f'data-theme="{name}"'] = toks
+        return out
+
+
 # A value that names a colour. Used to tell a token that *should* have a theme
 # variant from one that legitimately does not.
 #
@@ -510,7 +573,8 @@ def is_colour(value: str) -> bool:
 THEME_INVARIANT: set[str] = set()
 
 
-def check_every_colour_themes(all_blocks: list[ThemeBlocks]) -> list[str]:
+def check_every_colour_themes(all_blocks: list[ThemeBlocks], repo: Path,
+                              theme_invariant: set[str]) -> list[str]:
     """A colour declared in the base :root must appear in every override block.
 
     This is the check that was missing, and its absence was not an oversight in
@@ -538,18 +602,18 @@ def check_every_colour_themes(all_blocks: list[ThemeBlocks]) -> list[str]:
             continue
 
         for key, value in sorted(blocks.base.items()):
-            if not is_colour(value) or key in THEME_INVARIANT:
+            if not is_colour(value) or key in theme_invariant:
                 continue
             absent = [where for where, toks in overrides.items() if key not in toks]
             if len(absent) == len(overrides):
                 out.append(
-                    f"{rel(path)}: {key} is a colour ({value}) declared only in "
+                    f"{rel(path, repo)}: {key} is a colour ({value}) declared only in "
                     "the base :root — it never themes, while its neighbours do. "
                     "Give it a variant in each override, or add it to "
                     "THEME_INVARIANT here and say why.")
             elif absent:
                 out.append(
-                    f"{rel(path)}: {key} themes in some blocks but is missing "
+                    f"{rel(path, repo)}: {key} themes in some blocks but is missing "
                     f"from {', '.join(absent)} — it will fall back to the base "
                     f"value ({value}) there while its neighbours change.")
     return out
@@ -594,64 +658,7 @@ def has_theming(text: str) -> bool:
         re.search(THEME_RE.format(name=n), text) for n in ("light", "dark"))
 
 
-class ThemeBlocks:
-    """Every theme block in one document, read once.
-
-    check_theme_parity and check_every_colour_themes each
-    re-derived the base :root, the media block and the two data-theme blocks,
-    with their own try/except wording around each. The mutual-deferral bug came
-    from exactly that shape - one function's error handling
-    silently depending on the other's, under a combination neither covered.
-    Fixing the one combination while leaving the duplication in place invites
-    the next one, so the reading happens once and both checks consume it.
-    """
-
-    def __init__(self, path: Path) -> None:
-        self.path = path
-        self.text = read(path)
-        self.errors: list[str] = []
-        self.themes = has_theming(self.text)
-
-        self.base = self._read(BASE_ROOT_RE, "the base :root", outside_media=True)
-        m = MEDIA_RE.search(self.text)
-        self.media_name = m.group(1).lower() if m else None
-        self.media = (self._read(MEDIA_RE_BRACE,
-                                 f"the prefers-color-scheme:{self.media_name} block")
-                      if m else None)
-        self.themed = {
-            name: self._read(re.compile(THEME_RE.format(name=name)),
-                             f'the data-theme="{name}" block', quiet=True)
-            for name in ("light", "dark")
-        }
-
-    def _read(self, pattern, what: str, *, outside_media: bool = False,
-              quiet: bool = False) -> dict[str, str] | None:
-        try:
-            return tokens(block(self.text, pattern, outside_media=outside_media))
-        except BlockNotFound as exc:
-            # `quiet` covers the blocks a document may legitimately not have.
-            # Everything else is reported as a failure OF THIS CHECK, in those
-            # words, because an unreadable block used to surface as a page of
-            # invented colour mismatches.
-            if not quiet and self.themes:
-                self.errors.append(
-                    f"{rel(self.path)}: this document themes, but {what} could "
-                    f"not be read ({exc}). This is a failure of this check, "
-                    "not a colour mismatch.")
-            return None
-
-    def overrides(self) -> dict[str, dict[str, str]]:
-        """The readable override blocks, labelled as a reader would name them."""
-        out = {}
-        if self.media is not None:
-            out[f"prefers-color-scheme:{self.media_name}"] = self.media
-        for name, toks in self.themed.items():
-            if toks is not None:
-                out[f'data-theme="{name}"'] = toks
-        return out
-
-
-def check_theme_parity(all_blocks: list[ThemeBlocks]) -> list[str]:
+def check_theme_parity(all_blocks: list[ThemeBlocks], repo: Path) -> list[str]:
     """The two ways of reaching a theme must agree.
 
     A viewer's OS preference arrives as `prefers-color-scheme`; their explicit
@@ -672,7 +679,7 @@ def check_theme_parity(all_blocks: list[ThemeBlocks]) -> list[str]:
             continue  # no theme toggle; nothing can disagree
 
         if blocks.media_name is None:
-            out.append(f"{rel(path)}: has data-theme blocks but no "
+            out.append(f"{rel(path, repo)}: has data-theme blocks but no "
                        "prefers-color-scheme query; the OS preference is ignored")
             continue
         media_name = blocks.media_name
@@ -687,7 +694,7 @@ def check_theme_parity(all_blocks: list[ThemeBlocks]) -> list[str]:
             a, b = blocks.media.get(key), blocks.themed[media_name].get(key)
             if a != b:
                 out.append(
-                    f"{rel(path)}: {key} is {a!r} under "
+                    f"{rel(path, repo)}: {key} is {a!r} under "
                     f"prefers-color-scheme:{media_name} but {b!r} under "
                     f'data-theme="{media_name}" — the toggle and the OS '
                     "preference would disagree")
@@ -699,7 +706,7 @@ def check_theme_parity(all_blocks: list[ThemeBlocks]) -> list[str]:
             got = blocks.base.get(key)
             if got != want:
                 out.append(
-                    f"{rel(path)}: {key} is {got!r} in the base :root but "
+                    f"{rel(path, repo)}: {key} is {got!r} in the base :root but "
                     f'{want!r} under data-theme="{other}" — these are the same '
                     "theme and must match")
     return out
@@ -730,7 +737,7 @@ YAML_COMMENT_RE = re.compile(r"^\s*#.*$", re.M)
 BOARD = "docs/big-board.html"
 
 
-def check_board_harness_count() -> list[str]:
+def check_board_harness_count(repo: Path) -> list[str]:
     """The board's headline harness count must match what CI actually runs.
 
     The board is a static snapshot and says so, but "how many harnesses run in
@@ -743,8 +750,8 @@ def check_board_harness_count() -> list[str]:
     This does not make the board live. It pins the one number that can be
     derived, so the document cannot claim more coverage than exists.
     """
-    board = REPO / BOARD
-    workflow = REPO / ".github/workflows/checks.yml"
+    board = repo / BOARD
+    workflow = repo / ".github/workflows/checks.yml"
     if not board.exists() or not workflow.exists():
         return []
 
@@ -781,36 +788,30 @@ def check_board_harness_count() -> list[str]:
 
 def main(docs_root: Path | None = None, repo_root: Path | None = None,
          theme_invariant: set[str] | None = None) -> int:
-    """Run every check. Roots are arguments so a caller need not reach in.
+    """Run every check against the given roots.
 
-    harness_test.py used to assign artifact_test.DOCS and .REPO directly and
-    restore them in a finally. Correct for a sequential script and silently
-    wrong under any parallel runner - two tests would fight over one module's
-    globals. Passing them removes the shared mutable state rather than
-    documenting it.
+    NO GLOBAL MUTATION. An earlier version assigned DOCS, REPO and
+    THEME_INVARIANT onto the module and restored them in a finally, with a
+    comment claiming that removed the shared mutable state - it did not. It
+    moved the race from the caller into this function, where the window
+    between saving and restoring is just as open to a second concurrent call.
+    Review caught the overclaim, which was mine and in a comment about
+    robustness.
+
+    The module-level DOCS and REPO are defaults for a direct run and nothing
+    reads them after this line.
     """
-    global DOCS, REPO, THEME_INVARIANT
-    saved = (DOCS, REPO, THEME_INVARIANT)
-    if docs_root is not None:
-        DOCS = docs_root
-    if repo_root is not None:
-        REPO = repo_root
-    if theme_invariant is not None:
-        THEME_INVARIANT = theme_invariant
-    try:
-        return _run()
-    finally:
-        DOCS, REPO, THEME_INVARIANT = saved
+    docs = docs_root if docs_root is not None else DOCS
+    repo = repo_root if repo_root is not None else REPO
+    invariant = theme_invariant if theme_invariant is not None else THEME_INVARIANT
 
-
-def _run() -> int:
-    if not DOCS.is_dir():
+    if not docs.is_dir():
         print("docs artifact test: FAILED")
         print("  docs/ is missing; this check cannot run, which is a failure "
               "rather than a pass.")
         return 1
 
-    files = html_files()
+    files = html_files(docs)
     if not files:
         print("docs artifact test: FAILED")
         print("  no HTML under docs/. If the documents were removed on purpose, "
@@ -820,19 +821,19 @@ def _run() -> int:
 
     # Read once, here. Both theme checks used to build their own ThemeBlocks,
     # and the errors were emitted by whichever of them happened to run - a
-    # coupling held by a comment, in a file whose second half is a record of
-    # comment-held couplings failing. This file has already had one of those; leaving the
-    # shape in place invites the next. main() now owns the read and the
-    # reporting, so removing or reordering either check cannot make an
-    # unreadable block go quiet.
-    all_blocks = [ThemeBlocks(path) for path in files]
+    # coupling held by a comment. main() owns the read and the reporting, so
+    # removing or reordering either check cannot make an unreadable block go
+    # quiet.
+    all_blocks = [ThemeBlocks(path, repo) for path in files]
     block_errors = [err for blocks in all_blocks for err in blocks.errors]
 
-    failures = (check_layout() + check_parses() + check_shared_widget()
+    failures = (check_layout()
+                + check_parses(docs, repo)
+                + check_shared_widget(docs, repo)
                 + block_errors
-                + check_theme_parity(all_blocks)
-                + check_every_colour_themes(all_blocks)
-                + check_board_harness_count())
+                + check_theme_parity(all_blocks, repo)
+                + check_every_colour_themes(all_blocks, repo, invariant)
+                + check_board_harness_count(repo))
 
     if failures:
         print("docs artifact test: FAILED")

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -158,7 +158,10 @@ class ArtifactDocument(HTMLParser):
         Caught by the real documents, again.
         """
         self.handle_starttag(tag, attrs)
-        foreign = any(t in FOREIGN for t, _ in self.stack[:-1])
+        # `self.stack`, not `self.stack[:-1]`. The tag just pushed counts:
+        # a bare `<svg/>` with no children is itself foreign content and does
+        # self-close, and excluding it reported that as an unbalanced <svg>.
+        foreign = any(t in FOREIGN for t, _ in self.stack)
         if foreign and self.stack and self.stack[-1][0] == tag:
             self.stack.pop()
 
@@ -247,7 +250,11 @@ def check_parses() -> list[str]:
 # this file exists to remove.
 SCRIPT_RE = re.compile(
     r"""<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>(.*?)</script>""", re.S | re.I)
-TYPE_RE = re.compile(r"""\btype\s*=\s*["']?([^"'\s>]+)""", re.I)
+# `\btype` was the first version, and `\b` matches at the hyphen/letter
+# boundary in `data-type` - so a widget carrying `data-type="foo"` was
+# classified by that instead, and with both attributes present the data- one
+# won, because search() returns the first match. Anchored on start-or-space.
+TYPE_RE = re.compile(r"""(?:^|\s)type\s*=\s*["']?([^"'\s>]+)""", re.I)
 
 
 def script_problem(attrs: str, body: str) -> str | None:
@@ -263,8 +270,17 @@ def script_problem(attrs: str, body: str) -> str | None:
     in its own introduction.
     """
     if "src=" in attrs.lower():
-        return ("loads an external script. This harness cannot compare it, and "
-                "a standalone document should not need one.")
+        # Stated as a limit of this harness, NOT as a verdict on the
+        # architecture. An earlier wording said "a standalone document should
+        # not need one", which quietly encodes "keep it pasted, but check the
+        # paste" - and extracting the widget to one real file is the actual fix
+        # for the drift this check exists to detect. Refusing what this cannot
+        # read is right; declaring it wrong is not this file's call. See #43,
+        # which holds the toolchain decision for these documents.
+        return ("loads an external script, which this harness has no way to "
+                "compare. If the widget is being extracted to a shared file, "
+                "teach this check to follow it - see #43 - rather than working "
+                "around this message.")
     if "<!--" in body:
         return ("contains `<!--`, which opens the double-escaped state where "
                 "`</script>` no longer ends the element. This harness reads "
@@ -437,7 +453,23 @@ def media_spans(text: str) -> list[tuple[int, int]]:
 
 # A value that names a colour. Used to tell a token that *should* have a theme
 # variant from one that legitimately does not.
-COLOUR_RE = re.compile(r"^(#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|color-mix\()")
+#
+# KNOWN LIMIT, and it is the same shape as the defect this check was added for.
+# `--ultraviolet` was missed because nothing looked at unthemed tokens at all;
+# a token set to a CSS keyword outside the list below - `rebeccapurple`, say -
+# is still missed, because it looks like an identifier and so does `system-ui`.
+# The CSS named-colour set is 148 entries and inlining it here would be more
+# source than the check it serves. The residual is stated rather than closed:
+# a colour named by an uncommon keyword and declared only in the base :root
+# will not be flagged. THEME_INVARIANT below is where an intentional exemption
+# goes; this is where an unintentional one still hides.
+COLOUR_RE = re.compile(
+    r"^(#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|color-mix\(|var\(|"
+    r"transparent\b|currentcolor\b|"
+    r"(?:black|white|red|green|blue|yellow|orange|purple|grey|gray|"
+    r"pink|brown|cyan|magenta|violet|indigo|teal|navy|olive|maroon|"
+    r"silver|gold|beige|ivory|coral|salmon|crimson|lime|aqua|fuchsia)\b)",
+    re.I)
 
 # Colour tokens that are deliberately the same in every theme. Empty today.
 # Pinned as an explicit list rather than inferred, on the same reasoning as
@@ -688,6 +720,21 @@ def check_board_harness_count() -> list[str]:
 
     body = YAML_COMMENT_RE.sub("", read(workflow))
     actual = sorted(set(HARNESS_STEP_RE.findall(body)))
+
+    # Anything under tests/ that this counter cannot attribute to a
+    # `python3 <path>` invocation is named rather than dropped. A step using
+    # pytest, tox, or a wrapper script would otherwise fall out of the count
+    # silently and the board would be "correct" about a number that had
+    # stopped describing CI - skip-and-pass, in the check that exists to stop
+    # a document overclaiming its own coverage.
+    mentioned = set(re.findall(r"(tests/\S+\.py)(?!\S)", body))
+    uncounted = sorted(mentioned - set(actual))
+    if uncounted:
+        return [f"{BOARD}: checks.yml references {', '.join(uncounted)} in a "
+                "form this counter cannot read - it counts `python3 <path>` "
+                "invocations only. Either the step changed shape or a test is "
+                "run by a wrapper; teach HARNESS_STEP_RE rather than letting "
+                "the count quietly stop describing CI."]
     text = read(board)
     m = re.search(r'data-harness-count="(\d+)"', text)
     if not m:

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -114,6 +114,8 @@ class ArtifactDocument(HTMLParser):
         super().__init__(convert_charrefs=True)
         self.stack: list[tuple[str, int]] = []
         self.errors: list[str] = []
+        self.scripts: list[tuple[dict, str]] = []
+        self._script: list | None = None
         self.doctype = False
         self.charset = False
         self.body = False
@@ -136,6 +138,8 @@ class ArtifactDocument(HTMLParser):
             elif (a.get("http-equiv", "").strip().lower() == "content-type"
                   and "utf-8" in a.get("content", "").lower()):
                 self.charset = True
+        if tag == "script":
+            self._script = [a, ""]
         if tag == "body":
             self.body = True
         if tag == "html":
@@ -165,7 +169,14 @@ class ArtifactDocument(HTMLParser):
         if foreign and self.stack and self.stack[-1][0] == tag:
             self.stack.pop()
 
+    def handle_data(self, data: str) -> None:
+        if self._script is not None:
+            self._script[1] += data
+
     def handle_endtag(self, tag: str) -> None:
+        if tag == "script" and self._script is not None:
+            self.scripts.append((self._script[0], self._script[1]))
+            self._script = None
         if not self.stack:
             self.errors.append(f"line {self.getpos()[0]}: stray </{tag}>")
             return
@@ -225,39 +236,32 @@ def check_parses() -> list[str]:
     return out
 
 
-# Any script tag, however it is spelled. The first version of this matched a
-# bare `<script>` only, and the failure mode was the worst available: a second
-# document written as `<script type="module">` was silently excluded from the
-# comparison, so the check reported "one shared widget" across two documents
-# whose widgets differed. Verified as a real false pass before this was
-# changed, not reasoned about. A check that goes quiet exactly when someone
-# deviates is the defect this file exists to catch, and it was in this file.
+# SCRIPT_RE and TYPE_RE used to live here: a hand-rolled `<script>` matcher
+# and an attribute reader beside it. Nearly every false pass this file has
+# shipped came from that one decision to re-parse text the ArtifactDocument
+# walk was already reading -
 #
-# Non-greedy to the first `</script>`, which was raised in review as the same
-# fragility the CSS scanner has - a `</script>` inside a JS string would end
-# the match early. Checked rather than assumed, and the premise does not hold:
-# an unescaped `</script>` inside a string ends the *element* too. HTML has no
-# escaping inside raw text, which is why the idiom is to write `<\/script>`.
+#     a bare `<script>` pattern skipped `<script type="module">` entirely
+#     `[^>]*` ended the tag at a `>` inside an attribute value
+#     `\btype` matched inside `data-type` and won over the real attribute
 #
-#     >>> feed('<script>var s = "</script>"; alert(1)</script>')
-#     script body: 'var s = "'
+# - three separate patches to three symptoms of the same cause. html.parser
+# puts <script> in CDATA_CONTENT_ELEMENTS, so it handles the raw-text body, any
+# attribute spelling, and quoted `>` for free, and it agrees with a browser on
+# where the element ends. Verified against all five shapes before switching,
+# including the double-escaped state a `<!--` opens.
 #
-# So this agrees with the parser rather than approximating it. The genuine edge
-# is the double-escaped state a `<!--` opens, which nothing here uses.
-# The attribute group understands quoting. `[^>]*` was the first version, and
-# `data-x=">"` ended it mid-attribute - which did not fail, it collected a
-# script whose body began `">` and compared that. Silently wrong is the mode
-# this file exists to remove.
-SCRIPT_RE = re.compile(
-    r"""<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>(.*?)</script>""", re.S | re.I)
-# `\btype` was the first version, and `\b` matches at the hyphen/letter
-# boundary in `data-type` - so a widget carrying `data-type="foo"` was
-# classified by that instead, and with both attributes present the data- one
-# won, because search() returns the first match. Anchored on start-or-space.
-TYPE_RE = re.compile(r"""(?:^|\s)type\s*=\s*["']?([^"'\s>]+)""", re.I)
+# Scripts now come off the same parse as the tag balance. There is one reader.
 
 
-def script_problem(attrs: str, body: str) -> str | None:
+def scripts_in(path: Path) -> list[tuple[dict, str]]:
+    """Every <script> in a document, off the same parse as the tag balance."""
+    doc = ArtifactDocument()
+    doc.feed(read(path))
+    return doc.scripts
+
+
+def script_problem(attrs: dict, body: str) -> str | None:
     """Why this script cannot be compared, or None if it can.
 
     Returns the complaint rather than a bool because check_shared_widget must
@@ -269,7 +273,7 @@ def script_problem(attrs: str, body: str) -> str | None:
     stop two filters drifting, used by one of them. The drift it warns about,
     in its own introduction.
     """
-    if "src=" in attrs.lower():
+    if "src" in attrs:
         # Stated as a limit of this harness, NOT as a verdict on the
         # architecture. An earlier wording said "a standalone document should
         # not need one", which quietly encodes "keep it pasted, but check the
@@ -281,15 +285,15 @@ def script_problem(attrs: str, body: str) -> str | None:
                 "compare. If the widget is being extracted to a shared file, "
                 "teach this check to follow it - see #43 - rather than working "
                 "around this message.")
-    if "<!--" in body:
-        return ("contains `<!--`, which opens the double-escaped state where "
-                "`</script>` no longer ends the element. This harness reads "
-                "scripts with a regex that cannot follow that. Remove it, or "
-                "teach this check.")
+    # The `<!--` refusal that used to sit here was justified by the regex not
+    # being able to follow the double-escaped state. The parser can, and a rule
+    # outliving its reason is a rule nobody can argue with. Removed rather than
+    # kept for safety: refusing input this harness now reads correctly is the
+    # false-fail side of the same coin.
     return None
 
 
-def comparable_script(attrs: str, body: str) -> bool:
+def comparable_script(attrs: dict, body: str) -> bool:
     return script_problem(attrs, body) is None and bool(body.strip())
 
 
@@ -308,7 +312,7 @@ def check_shared_widget() -> list[str]:
     scripts: dict[str, list[str]] = {}
 
     for path in html_files():
-        for attrs, body in SCRIPT_RE.findall(read(path)):
+        for attrs, body in scripts_in(path):
             problem = script_problem(attrs, body)
             if problem is not None:
                 out.append(f"{rel(path)}: an inline script {problem}")
@@ -320,8 +324,9 @@ def check_shared_widget() -> list[str]:
                 # `<script type="module">` is not the same widget. Grouping on
                 # body alone would have traded the false pass this check just
                 # fixed for its mirror image.
-                kind = (TYPE_RE.search(attrs) or [None, "classic"])[1].lower()
-                where = rel(path) + (f" (<script{attrs}>)" if attrs.strip() else "")
+                kind = attrs.get("type", "classic").strip().lower() or "classic"
+                shown = " ".join(f'{k}="{v}"' for k, v in sorted(attrs.items()))
+                where = rel(path) + (f" (<script {shown}>)" if shown else "")
                 scripts.setdefault((kind, body), []).append(where)
 
     if len(scripts) > 1:
@@ -339,36 +344,36 @@ def check_shared_widget() -> list[str]:
 DECL_NAME_RE = re.compile(r"^\s*(--[\w-]+)\s*:\s*(.*)$", re.S)
 
 
-COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
+def scan_css(css: str):
+    """Yield (index, char, quoted) for every character outside a comment.
 
-
-def scan_css(css: str, stop: str):
-    """Walk CSS, yielding (index, char) for characters outside strings and comments.
-
-    `declarations()` and `body_at()` each hand-rolled this quote-tracking and
-    comment-skipping loop. That is the second time in this file that "should
-    have been one primitive" came up - the first is the widget this whole pull
-    request is about - and the two copies had already drifted: body_at learned
-    about strings in order to count braces safely, and declarations was written
-    afterwards without them and truncated `content: ";"`.
+    ONE definition of "inside a string" and "inside a comment", used by both
+    callers. The previous shape had scan_css skipping comments while
+    `declarations` sliced raw text and then ran COMMENT_RE over the pieces - a
+    second, weaker comment path layered on the first, added to patch a bug the
+    extraction had itself introduced. Two answers to one question is how this
+    file's worst defects started; a scanner is not the place to keep a spare.
     """
     quote, i, n = None, 0, len(css)
     while i < n:
         c = css[i]
         if quote:
-            if c == "\\":
+            yield i, c, True
+            if c == "\\" and i + 1 < n:
+                yield i + 1, css[i + 1], True
                 i += 2
                 continue
             if c == quote:
                 quote = None
         elif c in "\"'":
             quote = c
+            yield i, c, True
         elif c == "/" and css.startswith("/*", i):
             end = css.find("*/", i + 2)
             i = n if end < 0 else end + 2
             continue
-        elif c in stop:
-            yield i, c
+        else:
+            yield i, c, False
         i += 1
 
 
@@ -378,23 +383,17 @@ def declarations(css: str) -> list[str]:
     `([^;]+);` was the first version and it truncates `content: ";"` at the
     quote's semicolon. Braces separate as well as semicolons: the media blocks
     here wrap a nested `:root { ... }`, and splitting on `;` alone glued the
-    selector onto the first declaration and lost it - which the harness caught
-    the moment it ran. Noted because the regex this replaced did not have that
-    bug, and a fix that introduces one is worth saying out loud.
+    selector onto the first declaration and lost it.
     """
-    parts, last = [], 0
-    for i, _ in scan_css(css, ";{}"):
-        parts.append(css[last:i])
-        last = i + 1
-    parts.append(css[last:])
-    # Comments survive the split - scan_css steps over them so a `;` inside one
-    # cannot separate declarations, but the text is still in the slice, and a
-    # leading `/* ... */` breaks DECL_NAME_RE's anchor. The previous
-    # hand-rolled loop dropped comment characters as it went; extracting the
-    # scanner lost that, and every base :root opening with a comment came back
-    # missing its first token. Caught by the two real documents, NOT by
-    # harness_test - which is a gap in the meta-test, now closed with a case.
-    return [COMMENT_RE.sub(" ", part) for part in parts]
+    parts, buf = [], []
+    for _, c, quoted in scan_css(css):
+        if c in ";{}" and not quoted:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+    parts.append("".join(buf))
+    return parts
 
 
 MEDIA_RE = re.compile(r"@media\s*\(\s*prefers-color-scheme\s*:\s*(\w+)\s*\)", re.I)
@@ -409,14 +408,15 @@ class BlockNotFound(Exception):
 def body_at(text: str, brace_index: int) -> str:
     """Brace-balanced body starting at an opening brace.
 
-    Aware of strings and `/* */` comments through the shared scanner, because a
-    declaration like `content: "{"` would otherwise desync the counter and
-    silently truncate the block - producing a short token map and a page of
-    invented mismatches. Not a CSS parser; this is the smallest thing that is
-    not wrong here.
+    Strings and comments come from the shared scanner, because a declaration
+    like `content: "{"` would otherwise desync the counter and silently
+    truncate the block - producing a short token map and a page of invented
+    mismatches. Not a CSS parser; this is the smallest thing that is not wrong.
     """
     depth = 0
-    for i, c in scan_css(text[brace_index:], "{}"):
+    for i, c, quoted in scan_css(text[brace_index:]):
+        if quoted or c not in "{}":
+            continue
         depth += 1 if c == "{" else -1
         if depth == 0:
             return text[brace_index + 1:brace_index + i]
@@ -454,22 +454,52 @@ def media_spans(text: str) -> list[tuple[int, int]]:
 # A value that names a colour. Used to tell a token that *should* have a theme
 # variant from one that legitimately does not.
 #
-# KNOWN LIMIT, and it is the same shape as the defect this check was added for.
-# `--ultraviolet` was missed because nothing looked at unthemed tokens at all;
-# a token set to a CSS keyword outside the list below - `rebeccapurple`, say -
-# is still missed, because it looks like an identifier and so does `system-ui`.
-# The CSS named-colour set is 148 entries and inlining it here would be more
-# source than the check it serves. The residual is stated rather than closed:
-# a colour named by an uncommon keyword and declared only in the base :root
-# will not be flagged. THEME_INVARIANT below is where an intentional exemption
-# goes; this is where an unintentional one still hides.
-COLOUR_RE = re.compile(
-    r"^(#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|color-mix\(|var\(|"
-    r"transparent\b|currentcolor\b|"
-    r"(?:black|white|red|green|blue|yellow|orange|purple|grey|gray|"
-    r"pink|brown|cyan|magenta|violet|indigo|teal|navy|olive|maroon|"
-    r"silver|gold|beige|ivory|coral|salmon|crimson|lime|aqua|fuchsia)\b)",
-    re.I)
+# The named-colour set is complete - all 148 CSS keywords plus `transparent`
+# and `currentColor`. A partial list was the first version and it was the worst
+# of the three options: `red` and `transparent` were recognised while
+# `rebeccapurple` was not, so the check LOOKED exhaustive and silently skipped
+# the tokens nobody thought to add. That is the same shape as `--ultraviolet`,
+# which is the defect this check was written for. Either enumerate them or
+# narrow to hex and functions and say so; a partial set claims the first while
+# delivering the second.
+CSS_NAMED_COLOURS = frozenset("""
+aliceblue antiquewhite aqua aquamarine azure beige bisque black blanchedalmond
+blue blueviolet brown burlywood cadetblue chartreuse chocolate coral
+cornflowerblue cornsilk crimson cyan darkblue darkcyan darkgoldenrod darkgray
+darkgreen darkgrey darkkhaki darkmagenta darkolivegreen darkorange darkorchid
+darkred darksalmon darkseagreen darkslateblue darkslategray darkslategrey
+darkturquoise darkviolet deeppink deepskyblue dimgray dimgrey dodgerblue
+firebrick floralwhite forestgreen fuchsia gainsboro ghostwhite gold goldenrod
+gray green greenyellow grey honeydew hotpink indianred indigo ivory khaki
+lavender lavenderblush lawngreen lemonchiffon lightblue lightcoral lightcyan
+lightgoldenrodyellow lightgray lightgreen lightgrey lightpink lightsalmon
+lightseagreen lightskyblue lightslategray lightslategrey lightsteelblue
+lightyellow lime limegreen linen magenta maroon mediumaquamarine mediumblue
+mediumorchid mediumpurple mediumseagreen mediumslateblue mediumspringgreen
+mediumturquoise mediumvioletred midnightblue mintcream mistyrose moccasin
+navajowhite navy oldlace olive olivedrab orange orangered orchid palegoldenrod
+palegreen paleturquoise palevioletred papayawhip peachpuff peru pink plum
+powderblue purple rebeccapurple red rosybrown royalblue saddlebrown salmon
+sandybrown seagreen seashell sienna silver skyblue slateblue slategray
+slategrey snow springgreen steelblue tan teal thistle tomato turquoise violet
+wheat white whitesmoke yellow yellowgreen
+""".split())
+
+COLOUR_FUNC_RE = re.compile(
+    r"^(#[0-9a-fA-F]{3,8}|(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color|"
+    r"color-mix|light-dark)\s*\()")
+
+
+def is_colour(value: str) -> bool:
+    v = value.strip().lower()
+    if COLOUR_FUNC_RE.match(v):
+        return True
+    if v.startswith("var("):
+        # Indirection through another custom property. The target is themed or
+        # it is not, and this check will reach it under its own name.
+        return True
+    return v in CSS_NAMED_COLOURS or v in {"transparent", "currentcolor"}
+
 
 # Colour tokens that are deliberately the same in every theme. Empty today.
 # Pinned as an explicit list rather than inferred, on the same reasoning as
@@ -508,7 +538,7 @@ def check_every_colour_themes(all_blocks: list[ThemeBlocks]) -> list[str]:
             continue
 
         for key, value in sorted(blocks.base.items()):
-            if not COLOUR_RE.match(value) or key in THEME_INVARIANT:
+            if not is_colour(value) or key in THEME_INVARIANT:
                 continue
             absent = [where for where, toks in overrides.items() if key not in toks]
             if len(absent) == len(overrides):
@@ -749,7 +779,31 @@ def check_board_harness_count() -> list[str]:
     return []
 
 
-def main() -> int:
+def main(docs_root: Path | None = None, repo_root: Path | None = None,
+         theme_invariant: set[str] | None = None) -> int:
+    """Run every check. Roots are arguments so a caller need not reach in.
+
+    harness_test.py used to assign artifact_test.DOCS and .REPO directly and
+    restore them in a finally. Correct for a sequential script and silently
+    wrong under any parallel runner - two tests would fight over one module's
+    globals. Passing them removes the shared mutable state rather than
+    documenting it.
+    """
+    global DOCS, REPO, THEME_INVARIANT
+    saved = (DOCS, REPO, THEME_INVARIANT)
+    if docs_root is not None:
+        DOCS = docs_root
+    if repo_root is not None:
+        REPO = repo_root
+    if theme_invariant is not None:
+        THEME_INVARIANT = theme_invariant
+    try:
+        return _run()
+    finally:
+        DOCS, REPO, THEME_INVARIANT = saved
+
+
+def _run() -> int:
     if not DOCS.is_dir():
         print("docs artifact test: FAILED")
         print("  docs/ is missing; this check cannot run, which is a failure "
@@ -792,7 +846,7 @@ def main() -> int:
     # would have reported a widget that does not exist. A success line is a
     # claim like any other.
     n_widgets = len({body for path in files
-                     for attrs, body in SCRIPT_RE.findall(read(path))
+                     for attrs, body in scripts_in(path)
                      if comparable_script(attrs, body)})
     widget = ("no inline widget" if n_widgets == 0
               else f"{n_widgets} shared widget")

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -57,11 +57,21 @@ DOCS = REPO / "docs"
 # it would point DOCS somewhere with no HTML in it, and main()'s empty-set
 # branch would report "no HTML under docs/" as though the documents had been
 # deleted. Anchored so a moved file says what actually happened.
-if not (REPO / ".git").exists() and not (REPO / "tests" / "docs").is_dir():
+#
+# The first version of this guard was `if not .git and not tests/docs`, which
+# only fires when BOTH signals are wrong - so a nested repository, a submodule,
+# or a moved file with a .git at some other ancestor sails straight through. A
+# guard added to fix a fragility, carrying the same fragility. Review caught it.
+#
+# This asserts the one thing that is load-bearing: that parents[2] lands where
+# this file says it does. It cannot be satisfied by coincidence.
+_EXPECTED = REPO / "tests" / "docs" / "artifact_test.py"
+if Path(__file__).resolve() != _EXPECTED:
     raise SystemExit(
-        f"artifact_test.py: computed repository root {REPO} does not look like "
-        "one. This file moved and parents[2] no longer reaches the root; fix "
-        "the depth rather than letting the checks run against the wrong tree.")
+        f"artifact_test.py: parents[2] resolves to {REPO}, which would put this "
+        f"file at {_EXPECTED} - it is actually at {Path(__file__).resolve()}. "
+        "The file moved; fix the depth rather than letting the checks run "
+        "against the wrong tree.")
 
 # Elements with no closing tag. A hand-written list rather than a dependency;
 # if one is missing the parser reports a false unclosed tag, which fails loudly
@@ -226,6 +236,19 @@ def check_shared_widget() -> list[str]:
                            f"(<script{attrs}>). This harness cannot compare it, "
                            "and a standalone document should not need one.")
                 continue
+            if "<!--" in body:
+                # The one case where this regex genuinely disagrees with the
+                # parser: `<!--` inside a script opens the double-escaped
+                # state, in which `</script>` no longer ends the element. The
+                # docstring named this as "nothing here uses it", which is a
+                # gap with no guard - true until someone pastes a comment
+                # guard into the widget. Refused rather than mis-parsed.
+                out.append(f"{rel(path)}: an inline script contains `<!--`, "
+                           "which opens the double-escaped state where "
+                           "`</script>` no longer ends the element. This "
+                           "harness reads scripts with a regex that cannot "
+                           "follow that. Remove it, or teach this check.")
+                continue
             if body.strip():
                 where = rel(path) + (f" (<script{attrs}>)" if attrs.strip() else "")
                 scripts.setdefault(body, []).append(where)
@@ -245,48 +268,64 @@ def check_shared_widget() -> list[str]:
 DECL_NAME_RE = re.compile(r"^\s*(--[\w-]+)\s*:\s*(.*)$", re.S)
 
 
-def declarations(css: str) -> list[str]:
-    """Split a declaration block on the semicolons that actually separate it.
+COMMENT_RE = re.compile(r"/\*.*?\*/", re.S)
 
-    `([^;]+);` was the first version and it truncates `content: ";"` at the
-    quote's semicolon. `body_at` already had to learn strings and comments to
-    count braces safely; splitting declarations needs the same knowledge and
-    was written without it, which is how one function in a file ends up
-    stricter than another about the same input.
+
+def scan_css(css: str, stop: str):
+    """Walk CSS, yielding (index, char) for characters outside strings and comments.
+
+    `declarations()` and `body_at()` each hand-rolled this quote-tracking and
+    comment-skipping loop. That is the second time in this file that "should
+    have been one primitive" came up - the first is the widget this whole pull
+    request is about - and the two copies had already drifted: body_at learned
+    about strings in order to count braces safely, and declarations was written
+    afterwards without them and truncated `content: ";"`.
     """
-    parts, buf, quote, i, n = [], [], None, 0, len(css)
+    quote, i, n = None, 0, len(css)
     while i < n:
         c = css[i]
         if quote:
-            buf.append(c)
-            if c == "\\" and i + 1 < n:
-                buf.append(css[i + 1])
+            if c == "\\":
                 i += 2
                 continue
             if c == quote:
                 quote = None
         elif c in "\"'":
             quote = c
-            buf.append(c)
         elif c == "/" and css.startswith("/*", i):
             end = css.find("*/", i + 2)
             i = n if end < 0 else end + 2
             continue
-        elif c in ";{}":
-            # Braces separate as well as semicolons. The media blocks here wrap
-            # a nested `:root { ... }`, so splitting on `;` alone glued the
-            # selector onto the first declaration and lost it - which the
-            # harness caught the moment it ran, reporting the first token of
-            # every media block as missing. Left as a comment because the
-            # regex this replaced did not have the bug, and a fix that
-            # introduces one is worth marking.
-            parts.append("".join(buf))
-            buf = []
-        else:
-            buf.append(c)
+        elif c in stop:
+            yield i, c
         i += 1
-    parts.append("".join(buf))
-    return parts
+
+
+def declarations(css: str) -> list[str]:
+    """Split a declaration block on the separators that actually separate it.
+
+    `([^;]+);` was the first version and it truncates `content: ";"` at the
+    quote's semicolon. Braces separate as well as semicolons: the media blocks
+    here wrap a nested `:root { ... }`, and splitting on `;` alone glued the
+    selector onto the first declaration and lost it - which the harness caught
+    the moment it ran. Noted because the regex this replaced did not have that
+    bug, and a fix that introduces one is worth saying out loud.
+    """
+    parts, last = [], 0
+    for i, _ in scan_css(css, ";{}"):
+        parts.append(css[last:i])
+        last = i + 1
+    parts.append(css[last:])
+    # Comments survive the split - scan_css steps over them so a `;` inside one
+    # cannot separate declarations, but the text is still in the slice, and a
+    # leading `/* ... */` breaks DECL_NAME_RE's anchor. The previous
+    # hand-rolled loop dropped comment characters as it went; extracting the
+    # scanner lost that, and every base :root opening with a comment came back
+    # missing its first token. Caught by the two real documents, NOT by
+    # harness_test - which is a gap in the meta-test, now closed with a case.
+    return [COMMENT_RE.sub(" ", part) for part in parts]
+
+
 MEDIA_RE = re.compile(r"@media\s*\(\s*prefers-color-scheme\s*:\s*(\w+)\s*\)", re.I)
 BASE_ROOT_RE = re.compile(r":root\s*\{")
 THEME_RE = r':root\s*\[\s*data-theme\s*=\s*["\']{name}["\']\s*\]\s*\{{'
@@ -299,34 +338,17 @@ class BlockNotFound(Exception):
 def body_at(text: str, brace_index: int) -> str:
     """Brace-balanced body starting at an opening brace.
 
-    Aware of strings and `/* */` comments, because a declaration like
-    `content: "{"` would otherwise desync the counter and silently truncate
-    the block — producing a short token map and a page of invented mismatches.
-    Not a CSS parser; this is the smallest thing that is not wrong here.
+    Aware of strings and `/* */` comments through the shared scanner, because a
+    declaration like `content: "{"` would otherwise desync the counter and
+    silently truncate the block - producing a short token map and a page of
+    invented mismatches. Not a CSS parser; this is the smallest thing that is
+    not wrong here.
     """
-    depth, i, n = 0, brace_index, len(text)
-    quote = None
-    while i < n:
-        c = text[i]
-        if quote:
-            if c == "\\":
-                i += 2
-                continue
-            if c == quote:
-                quote = None
-        elif c in "\"'":
-            quote = c
-        elif c == "/" and text.startswith("/*", i):
-            end = text.find("*/", i + 2)
-            i = n if end < 0 else end + 2
-            continue
-        elif c == "{":
-            depth += 1
-        elif c == "}":
-            depth -= 1
-            if depth == 0:
-                return text[brace_index + 1:i]
-        i += 1
+    depth = 0
+    for i, c in scan_css(text[brace_index:], "{}"):
+        depth += 1 if c == "{" else -1
+        if depth == 0:
+            return text[brace_index + 1:brace_index + i]
     raise BlockNotFound("unbalanced braces from this selector to end of file")
 
 
@@ -361,7 +383,7 @@ COLOUR_RE = re.compile(r"^(#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|color-mix\()")
 THEME_INVARIANT: set[str] = set()
 
 
-def check_every_colour_themes() -> list[str]:
+def check_every_colour_themes(all_blocks: list[ThemeBlocks]) -> list[str]:
     """A colour declared in the base :root must appear in every override block.
 
     This is the check that was missing, and its absence was not an oversight in
@@ -380,9 +402,8 @@ def check_every_colour_themes() -> list[str]:
     everything in the file.
     """
     out = []
-    for path in html_files():
-        blocks = ThemeBlocks(path)
-        out += blocks.errors
+    for blocks in all_blocks:
+        path = blocks.path
         if not blocks.themes or blocks.base is None:
             continue
         overrides = blocks.overrides()
@@ -503,7 +524,7 @@ class ThemeBlocks:
         return out
 
 
-def check_theme_parity() -> list[str]:
+def check_theme_parity(all_blocks: list[ThemeBlocks]) -> list[str]:
     """The two ways of reaching a theme must agree.
 
     A viewer's OS preference arrives as `prefers-color-scheme`; their explicit
@@ -518,12 +539,8 @@ def check_theme_parity() -> list[str]:
     in that way is why it is written like this.
     """
     out = []
-    for path in html_files():
-        blocks = ThemeBlocks(path)
-        # Errors are reported by check_every_colour_themes, which reads the same
-        # blocks. Not repeated here - but note this is a claim about a shared
-        # object, not two functions promising each other something. If that
-        # function is ever removed, this needs its own `out += blocks.errors`.
+    for blocks in all_blocks:
+        path = blocks.path
         if not any(v for v in blocks.themed.values()):
             continue  # no theme toggle; nothing can disagree
 
@@ -566,6 +583,43 @@ MEDIA_RE_BRACE = re.compile(
     r"@media\s*\(\s*prefers-color-scheme\s*:\s*\w+\s*\)\s*\{", re.I)
 
 
+HARNESS_STEP_RE = re.compile(r"run:\s*python3\s+(tests/\S+\.py)")
+BOARD = "docs/big-board.html"
+
+
+def check_board_harness_count() -> list[str]:
+    """The board's headline harness count must match what CI actually runs.
+
+    The board is a static snapshot and says so, but "how many harnesses run in
+    CI" is not a fact about the day it was written - it is a fact about the
+    repository, checkable at any moment, and it was WRONG IN THE PULL REQUEST
+    THAT ADDED IT: checks.yml ran eight, the board said six. A page whose
+    subject is checks that report without checking, misreporting the number of
+    checks.
+
+    This does not make the board live. It pins the one number that can be
+    derived, so the document cannot claim more coverage than exists.
+    """
+    board = REPO / BOARD
+    workflow = REPO / ".github/workflows/checks.yml"
+    if not board.exists() or not workflow.exists():
+        return []
+
+    actual = sorted(set(HARNESS_STEP_RE.findall(read(workflow))))
+    text = read(board)
+    m = re.search(r'data-harness-count="(\d+)"', text)
+    if not m:
+        return [f"{BOARD}: no data-harness-count attribute. It states a number "
+                "of harnesses in prose; that number needs to be machine-"
+                f"checkable against checks.yml, which runs {len(actual)}."]
+    claimed = int(m.group(1))
+    if claimed != len(actual):
+        return [f"{BOARD}: claims {claimed} harnesses; checks.yml runs "
+                f"{len(actual)} ({', '.join(actual)}). The board was already "
+                "wrong about this once, in the pull request that added it."]
+    return []
+
+
 def main() -> int:
     if not DOCS.is_dir():
         print("docs artifact test: FAILED")
@@ -581,8 +635,20 @@ def main() -> int:
               "check that passes because it found nothing to check.")
         return 1
 
-    failures = (check_parses() + check_shared_widget()
-                + check_theme_parity() + check_every_colour_themes())
+    # Read once, here. Both theme checks used to build their own ThemeBlocks,
+    # and the errors were emitted by whichever of them happened to run - a
+    # coupling held by a comment, in a file whose second half is a record of
+    # comment-held couplings failing. Round 6 found one of those; leaving the
+    # shape in place invites the next. main() now owns the read and the
+    # reporting, so removing or reordering either check cannot make an
+    # unreadable block go quiet.
+    all_blocks = [ThemeBlocks(path) for path in files]
+    block_errors = [err for blocks in all_blocks for err in blocks.errors]
+
+    failures = (check_parses() + check_shared_widget() + block_errors
+                + check_theme_parity(all_blocks)
+                + check_every_colour_themes(all_blocks)
+                + check_board_harness_count())
 
     if failures:
         print("docs artifact test: FAILED")

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -65,13 +65,26 @@ DOCS = REPO / "docs"
 #
 # This asserts the one thing that is load-bearing: that parents[2] lands where
 # this file says it does. It cannot be satisfied by coincidence.
-_EXPECTED = REPO / "tests" / "docs" / "artifact_test.py"
-if Path(__file__).resolve() != _EXPECTED:
-    raise SystemExit(
-        f"artifact_test.py: parents[2] resolves to {REPO}, which would put this "
-        f"file at {_EXPECTED} - it is actually at {Path(__file__).resolve()}. "
-        "The file moved; fix the depth rather than letting the checks run "
-        "against the wrong tree.")
+def check_layout() -> list[str]:
+    """parents[2] must land where this file says this file is.
+
+    Derived from __file__ rather than from REPO, which harness_test.py
+    reassigns to a scratch directory - so this asks about the source tree
+    either way.
+
+    Called from main() rather than run at import. A bare `raise SystemExit` at
+    module level executes as a side effect of `import`, which works today only
+    because the one importer does so from the real path; coverage, a linter or
+    a doc tool would trip it.
+    """
+    here = Path(__file__).resolve()
+    if here != here.parents[2] / "tests" / "docs" / "artifact_test.py":
+        return [f"parents[2] resolves to {here.parents[2]}, which would put "
+                f"this file at {here.parents[2] / 'tests/docs/artifact_test.py'} "
+                f"- it is actually at {here}. The file moved; fix the depth "
+                "rather than letting the checks run against the wrong tree."]
+    return []
+
 
 # Elements with no closing tag. A hand-written list rather than a dependency;
 # if one is missing the parser reports a false unclosed tag, which fails loudly
@@ -80,6 +93,11 @@ VOID = {
     "area", "base", "br", "col", "embed", "hr", "img", "input",
     "link", "meta", "param", "source", "track", "wbr",
 }
+
+# Subtrees parsed as foreign content, where XML rules apply and `<circle/>`
+# genuinely self-closes. Outside these, a trailing slash is ignored by the
+# parser and the element stays open.
+FOREIGN = {"svg", "math"}
 
 
 class ArtifactDocument(HTMLParser):
@@ -126,8 +144,22 @@ class ArtifactDocument(HTMLParser):
             self.stack.append((tag, self.getpos()[0]))
 
     def handle_startendtag(self, tag: str, attrs) -> None:
+        """`<x/>` self-closes only where the parser is in foreign content.
+
+        In HTML proper the slash is ignored and a closing tag is still
+        required, so the previous version - which popped the stack for any
+        self-closed tag - let a genuinely unclosed `<div/>` parse clean here
+        and wrong in a browser.
+
+        Inside an <svg> or <math> subtree the rules are XML's and `<circle/>`
+        really does close. The first fix for the <div/> case did not make that
+        distinction and reported thirty unclosed tags in the calibration
+        brief's inline SVG - correct about HTML, wrong about the document.
+        Caught by the real documents, again.
+        """
         self.handle_starttag(tag, attrs)
-        if self.stack and self.stack[-1][0] == tag:
+        foreign = any(t in FOREIGN for t, _ in self.stack[:-1])
+        if foreign and self.stack and self.stack[-1][0] == tag:
             self.stack.pop()
 
     def handle_endtag(self, tag: str) -> None:
@@ -209,7 +241,13 @@ def check_parses() -> list[str]:
 #
 # So this agrees with the parser rather than approximating it. The genuine edge
 # is the double-escaped state a `<!--` opens, which nothing here uses.
-SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.S | re.I)
+# The attribute group understands quoting. `[^>]*` was the first version, and
+# `data-x=">"` ended it mid-attribute - which did not fail, it collected a
+# script whose body began `">` and compared that. Silently wrong is the mode
+# this file exists to remove.
+SCRIPT_RE = re.compile(
+    r"""<script\b((?:[^>"']|"[^"]*"|'[^']*')*)>(.*?)</script>""", re.S | re.I)
+TYPE_RE = re.compile(r"""\btype\s*=\s*["']?([^"'\s>]+)""", re.I)
 
 
 def script_problem(attrs: str, body: str) -> str | None:
@@ -260,16 +298,23 @@ def check_shared_widget() -> list[str]:
                 out.append(f"{rel(path)}: an inline script {problem}")
                 continue
             if body.strip():
+                # Keyed on (type, body), not body alone. A module script runs
+                # in strict mode, is deferred, and does not leak to global
+                # scope - identical text under `<script>` and
+                # `<script type="module">` is not the same widget. Grouping on
+                # body alone would have traded the false pass this check just
+                # fixed for its mirror image.
+                kind = (TYPE_RE.search(attrs) or [None, "classic"])[1].lower()
                 where = rel(path) + (f" (<script{attrs}>)" if attrs.strip() else "")
-                scripts.setdefault(body, []).append(where)
+                scripts.setdefault((kind, body), []).append(where)
 
     if len(scripts) > 1:
         out.append("inline scripts under docs/ have diverged; they are meant "
                    "to be one widget, pasted rather than shared:")
-        for body, wheres in scripts.items():
+        for (kind, body), wheres in scripts.items():
             first = next((ln.strip() for ln in body.splitlines() if ln.strip()), "")
-            out.append(f"    {len(body)} chars in {', '.join(wheres)}"
-                       f"  — starts {first[:60]!r}")
+            out.append(f"    {len(body)} chars, type={kind}, in "
+                       f"{', '.join(wheres)}  — starts {first[:60]!r}")
         out.append("    Extract it, or make them identical again. A comment "
                    "asking for this is what failed last time.")
     return out
@@ -682,7 +727,8 @@ def main() -> int:
     all_blocks = [ThemeBlocks(path) for path in files]
     block_errors = [err for blocks in all_blocks for err in blocks.errors]
 
-    failures = (check_parses() + check_shared_widget() + block_errors
+    failures = (check_layout() + check_parses() + check_shared_widget()
+                + block_errors
                 + check_theme_parity(all_blocks)
                 + check_every_colour_themes(all_blocks)
                 + check_board_harness_count())

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -22,6 +22,18 @@ scoped to `.claude/` on purpose, because `docs/csi/ROSTER.md` describes the
 shared-base arrangement without being one and would false-positive if swept in.
 Nothing here reads prose. It checks structure only.
 
+WHAT THIS DELIBERATELY DOES NOT DO, so "checked" is not overclaimed:
+
+  - It is not an HTML validator. `Balance` checks that tags nest and close.
+    HTML5 permits `<li>`, `<p>` and `<td>` to omit their closing tags; this
+    would report those as unclosed. Both current documents close everything
+    explicitly. A future document that does not is a reason to teach this
+    check the optional-end-tag rules, not a reason to loosen it into silence.
+  - CSS is read with a brace counter that understands strings and comments and
+    nothing else. It is not a CSS parser. Where it cannot locate a block it
+    says so as its own failure rather than reporting the empty result as a
+    hundred colour mismatches.
+
     python3 tests/docs/artifact_test.py
 
 Standard library only.
@@ -45,28 +57,45 @@ VOID = {
     "link", "meta", "param", "source", "track", "wbr",
 }
 
-REQUIRED_SCAFFOLD = (
-    "<!DOCTYPE html>",
-    '<meta charset="utf-8">',
-    "<body>",
-    "</html>",
-)
 
+class Document(HTMLParser):
+    """Tag balance and scaffolding, both read from the parse rather than the text.
 
-class Balance(HTMLParser):
-    """Tag balance only. Not a validator, and does not pretend to be one."""
+    The scaffolding was checked by substring match in the first version, which
+    would have failed a document using `<!doctype html>` or
+    `<meta charset='utf-8'>` — both perfectly valid. A check that rejects
+    correct input is not as bad as one that accepts wrong input, but it is
+    still a check that is wrong, and this file has no standing to ship one.
+    """
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self.stack: list[tuple[str, int]] = []
         self.errors: list[str] = []
+        self.doctype = False
+        self.charset = False
+        self.body = False
+        self.html = False
+
+    def handle_decl(self, decl: str) -> None:
+        if decl.strip().lower().startswith("doctype html"):
+            self.doctype = True
 
     def handle_starttag(self, tag: str, attrs) -> None:
+        a = {k.lower(): (v or "") for k, v in attrs}
+        if tag == "meta" and a.get("charset", "").strip().lower() == "utf-8":
+            self.charset = True
+        if tag == "body":
+            self.body = True
+        if tag == "html":
+            self.html = True
         if tag not in VOID:
             self.stack.append((tag, self.getpos()[0]))
 
     def handle_startendtag(self, tag: str, attrs) -> None:
-        pass  # self-closing, balanced by construction
+        self.handle_starttag(tag, attrs)
+        if self.stack and self.stack[-1][0] == tag:
+            self.stack.pop()
 
     def handle_endtag(self, tag: str) -> None:
         if not self.stack:
@@ -80,6 +109,18 @@ class Balance(HTMLParser):
                 f"line {self.getpos()[0]}: </{tag}> closes <{open_tag}> "
                 f"opened on line {line}"
             )
+
+    def scaffolding(self) -> list[str]:
+        missing = []
+        if not self.doctype:
+            missing.append("a <!DOCTYPE html> declaration")
+        if not self.charset:
+            missing.append('a <meta charset="utf-8">')
+        if not self.html:
+            missing.append("an <html> element")
+        if not self.body:
+            missing.append("a <body> element")
+        return missing
 
 
 def html_files() -> list[Path]:
@@ -104,21 +145,26 @@ def check_parses() -> list[str]:
     """
     out = []
     for path in html_files():
-        text = read(path)
-        for needed in REQUIRED_SCAFFOLD:
-            if needed not in text:
-                out.append(f"{rel(path)}: missing {needed!r} — a fragment, not "
-                           "a document. It will parse in quirks mode.")
-        parser = Balance()
-        parser.feed(text)
-        for err in parser.errors:
+        doc = Document()
+        doc.feed(read(path))
+        for missing in doc.scaffolding():
+            out.append(f"{rel(path)}: missing {missing} — a fragment, not a "
+                       "document. It will parse in quirks mode.")
+        for err in doc.errors:
             out.append(f"{rel(path)}: {err}")
-        for tag, line in parser.stack:
+        for tag, line in doc.stack:
             out.append(f"{rel(path)}: <{tag}> opened on line {line}, never closed")
     return out
 
 
-SCRIPT_RE = re.compile(r"<script>(.*?)</script>", re.S)
+# Any script tag, however it is spelled. The first version of this matched a
+# bare `<script>` only, and the failure mode was the worst available: a second
+# document written as `<script type="module">` was silently excluded from the
+# comparison, so the check reported "one shared widget" across two documents
+# whose widgets differed. Verified as a real false pass before this was
+# changed, not reasoned about. A check that goes quiet exactly when someone
+# deviates is the defect this file exists to catch, and it was in this file.
+SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.S | re.I)
 
 
 def check_shared_widget() -> list[str]:
@@ -132,51 +178,111 @@ def check_shared_widget() -> list[str]:
     If a document ever legitimately needs a *different* script, this check is
     the thing that must be reopened and argued with, on purpose.
     """
-    scripts: dict[str, list[Path]] = {}
+    out: list[str] = []
+    scripts: dict[str, list[str]] = {}
+
     for path in html_files():
-        for body in SCRIPT_RE.findall(read(path)):
+        for attrs, body in SCRIPT_RE.findall(read(path)):
+            if "src=" in attrs.lower():
+                # An external script has no body to compare. It also cannot be
+                # checked by this harness at all, so it is named rather than
+                # skipped: silence here is the thing being guarded against.
+                out.append(f"{rel(path)}: loads an external script "
+                           f"(<script{attrs}>). This harness cannot compare it, "
+                           "and a standalone document should not need one.")
+                continue
             if body.strip():
-                scripts.setdefault(body, []).append(path)
+                where = rel(path) + (f" (<script{attrs}>)" if attrs.strip() else "")
+                scripts.setdefault(body, []).append(where)
 
-    if len(scripts) <= 1:
-        return []
-
-    out = ["inline scripts under docs/ have diverged; they are meant to be one "
-           "widget, pasted rather than shared:"]
-    for body, paths in scripts.items():
-        first = next((ln.strip() for ln in body.splitlines() if ln.strip()), "")
-        out.append(f"    {len(body)} chars in {', '.join(rel(p) for p in paths)}"
-                   f"  — starts {first[:60]!r}")
-    out.append("    Extract it, or make them identical again. A comment asking "
-               "for this is what failed last time.")
+    if len(scripts) > 1:
+        out.append("inline scripts under docs/ have diverged; they are meant "
+                   "to be one widget, pasted rather than shared:")
+        for body, wheres in scripts.items():
+            first = next((ln.strip() for ln in body.splitlines() if ln.strip()), "")
+            out.append(f"    {len(body)} chars in {', '.join(wheres)}"
+                       f"  — starts {first[:60]!r}")
+        out.append("    Extract it, or make them identical again. A comment "
+                   "asking for this is what failed last time.")
     return out
 
 
 DECL_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;]+);")
+MEDIA_RE = re.compile(r"@media\s*\(\s*prefers-color-scheme\s*:\s*(\w+)\s*\)", re.I)
+BASE_ROOT_RE = re.compile(r":root\s*\{")
+THEME_RE = r':root\s*\[\s*data-theme\s*=\s*["\']{name}["\']\s*\]\s*\{{'
 
 
-def block_after(text: str, opener: str) -> str | None:
-    """The brace-balanced body following `opener`. None if absent."""
-    i = text.find(opener)
-    if i < 0:
-        return None
-    i = text.index("{", i)
-    depth, j = 0, i
-    while j < len(text):
-        if text[j] == "{":
+class BlockNotFound(Exception):
+    """Distinct from an empty block, so the error names the real problem."""
+
+
+def body_at(text: str, brace_index: int) -> str:
+    """Brace-balanced body starting at an opening brace.
+
+    Aware of strings and `/* */` comments, because a declaration like
+    `content: "{"` would otherwise desync the counter and silently truncate
+    the block — producing a short token map and a page of invented mismatches.
+    Not a CSS parser; this is the smallest thing that is not wrong here.
+    """
+    depth, i, n = 0, brace_index, len(text)
+    quote = None
+    while i < n:
+        c = text[i]
+        if quote:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "\"'":
+            quote = c
+        elif c == "/" and text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            i = n if end < 0 else end + 2
+            continue
+        elif c == "{":
             depth += 1
-        elif text[j] == "}":
+        elif c == "}":
             depth -= 1
             if depth == 0:
-                return text[i + 1:j]
-        j += 1
-    return None
+                return text[brace_index + 1:i]
+        i += 1
+    raise BlockNotFound("unbalanced braces from this selector to end of file")
 
 
-def tokens(block: str | None) -> dict[str, str]:
-    if block is None:
-        return {}
-    return {m.group(1): m.group(2).strip() for m in DECL_RE.finditer(block)}
+def media_spans(text: str) -> list[tuple[int, int]]:
+    spans = []
+    for m in MEDIA_RE.finditer(text):
+        open_i = text.index("{", m.end())
+        try:
+            spans.append((open_i, open_i + len(body_at(text, open_i))))
+        except BlockNotFound:
+            pass
+    return spans
+
+
+def block(text: str, pattern: re.Pattern[str], *, outside_media: bool = False) -> str:
+    """The body of the first block matching `pattern`. Raises if absent.
+
+    Selector matching is by regex rather than by literal indented text. The
+    first version searched for the string "\\n  :root {", so a reformat to four
+    spaces would have made the base block un-findable, the token map empty, and
+    every comparison a mismatch — sending the reader hunting a colour bug that
+    did not exist. Failing loudly is right; failing loudly about the wrong
+    thing is not.
+    """
+    spans = media_spans(text) if outside_media else []
+    for m in pattern.finditer(text):
+        i = m.end() - 1  # the opening brace
+        if any(lo < i < hi for lo, hi in spans):
+            continue
+        return body_at(text, i)
+    raise BlockNotFound(f"no block matching {pattern.pattern!r}")
+
+
+def tokens(css: str) -> dict[str, str]:
+    return {m.group(1): m.group(2).strip() for m in DECL_RE.finditer(css)}
 
 
 def check_theme_parity() -> list[str]:
@@ -185,35 +291,52 @@ def check_theme_parity() -> list[str]:
     A viewer's OS preference arrives as `prefers-color-scheme`; their explicit
     toggle arrives as `data-theme` on the root and has to beat the media query.
     That means the palette is written twice per theme, by construction — and
-    nothing stops the two from drifting apart, at which case flipping the
+    nothing stops the two from drifting apart, at which point flipping the
     toggle changes colours that flipping the OS setting does not.
 
     The two documents use opposite conventions — one has a dark base with a
     light media query, the other the reverse — so this checks the invariant
-    that holds either way rather than a fixed layout.
+    that holds either way rather than a fixed layout. That they already differ
+    in that way is why it is written like this.
     """
     out = []
     for path in html_files():
         text = read(path)
-        base = tokens(block_after(text, "\n  :root {"))
-        themed = {
-            name: tokens(block_after(text, f':root[data-theme="{name}"]'))
-            for name in ("light", "dark")
-        }
-        if not any(themed.values()):
-            continue
-
-        media = None
+        themed = {}
         for name in ("light", "dark"):
-            if f"@media (prefers-color-scheme: {name})" in text:
-                media = (name, tokens(block_after(
-                    text, f"@media (prefers-color-scheme: {name})")))
+            pattern = re.compile(THEME_RE.format(name=name))
+            try:
+                themed[name] = tokens(block(text, pattern))
+            except BlockNotFound:
+                themed[name] = None
+
+        if not any(v for v in themed.values()):
+            continue  # a document with no theme toggle has nothing to disagree
+
+        media = MEDIA_RE.search(text)
         if media is None:
             out.append(f"{rel(path)}: has data-theme blocks but no "
                        "prefers-color-scheme query; the OS preference is ignored")
             continue
+        media_name = media.group(1).lower()
+        other = "dark" if media_name == "light" else "light"
 
-        media_name, media_tokens = media
+        try:
+            media_tokens = tokens(block(text, MEDIA_RE_BRACE))
+        except BlockNotFound as exc:
+            out.append(f"{rel(path)}: could not read the "
+                       f"prefers-color-scheme:{media_name} block ({exc}). "
+                       "This is a failure of this check, not a colour mismatch.")
+            continue
+
+        for name in (media_name, other):
+            if themed.get(name) is None:
+                out.append(f"{rel(path)}: could not read the "
+                           f'data-theme="{name}" block. This is a failure of '
+                           "this check, not a colour mismatch.")
+        if themed.get(media_name) is None or themed.get(other) is None:
+            continue
+
         # 1. media(T) and [data-theme=T] are the same theme, reached two ways.
         for key in sorted(set(media_tokens) | set(themed[media_name])):
             a, b = media_tokens.get(key), themed[media_name].get(key)
@@ -227,7 +350,13 @@ def check_theme_parity() -> list[str]:
         # 2. The base :root carries the other theme; [data-theme=other] must
         #    restate it exactly. Only tokens the theme block names are compared,
         #    because :root also holds type and layout tokens that are not themed.
-        other = "dark" if media_name == "light" else "light"
+        try:
+            base = tokens(block(text, BASE_ROOT_RE, outside_media=True))
+        except BlockNotFound as exc:
+            out.append(f"{rel(path)}: could not read the base :root block "
+                       f"({exc}). This is a failure of this check, not a "
+                       "colour mismatch.")
+            continue
         for key, want in sorted(themed[other].items()):
             got = base.get(key)
             if got != want:
@@ -236,6 +365,11 @@ def check_theme_parity() -> list[str]:
                     f'{want!r} under data-theme="{other}" — these are the same '
                     "theme and must match")
     return out
+
+
+# The media query and its opening brace, so `block` can find the body.
+MEDIA_RE_BRACE = re.compile(
+    r"@media\s*\(\s*prefers-color-scheme\s*:\s*\w+\s*\)\s*\{", re.I)
 
 
 def main() -> int:

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -212,17 +212,31 @@ def check_parses() -> list[str]:
 SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.S | re.I)
 
 
-def comparable_script(attrs: str, body: str) -> bool:
-    """Whether this script is one the widget comparison can speak about.
+def script_problem(attrs: str, body: str) -> str | None:
+    """Why this script cannot be compared, or None if it can.
 
-    check_shared_widget skips external and `<!--`-bearing scripts; main()'s
-    success line counts inline widgets. Two filters, one definition - they are
-    not reachable out of step today only because the check runs first. Sharing
-    the predicate means a reordering cannot make the count and the comparison
-    disagree.
+    Returns the complaint rather than a bool because check_shared_widget must
+    say why it is skipping - silence there is the thing being guarded against -
+    while main()'s count only needs the verdict. One definition, two readings.
+
+    The first version of this was a bool that only main() called, while
+    check_shared_widget kept its three conditions inline: a helper written to
+    stop two filters drifting, used by one of them. The drift it warns about,
+    in its own introduction.
     """
-    return ("src=" not in attrs.lower() and "<!--" not in body
-            and bool(body.strip()))
+    if "src=" in attrs.lower():
+        return ("loads an external script. This harness cannot compare it, and "
+                "a standalone document should not need one.")
+    if "<!--" in body:
+        return ("contains `<!--`, which opens the double-escaped state where "
+                "`</script>` no longer ends the element. This harness reads "
+                "scripts with a regex that cannot follow that. Remove it, or "
+                "teach this check.")
+    return None
+
+
+def comparable_script(attrs: str, body: str) -> bool:
+    return script_problem(attrs, body) is None and bool(body.strip())
 
 
 def check_shared_widget() -> list[str]:
@@ -241,26 +255,9 @@ def check_shared_widget() -> list[str]:
 
     for path in html_files():
         for attrs, body in SCRIPT_RE.findall(read(path)):
-            if "src=" in attrs.lower():
-                # An external script has no body to compare. It also cannot be
-                # checked by this harness at all, so it is named rather than
-                # skipped: silence here is the thing being guarded against.
-                out.append(f"{rel(path)}: loads an external script "
-                           f"(<script{attrs}>). This harness cannot compare it, "
-                           "and a standalone document should not need one.")
-                continue
-            if "<!--" in body:
-                # The one case where this regex genuinely disagrees with the
-                # parser: `<!--` inside a script opens the double-escaped
-                # state, in which `</script>` no longer ends the element. The
-                # docstring named this as "nothing here uses it", which is a
-                # gap with no guard - true until someone pastes a comment
-                # guard into the widget. Refused rather than mis-parsed.
-                out.append(f"{rel(path)}: an inline script contains `<!--`, "
-                           "which opens the double-escaped state where "
-                           "`</script>` no longer ends the element. This "
-                           "harness reads scripts with a regex that cannot "
-                           "follow that. Remove it, or teach this check.")
+            problem = script_problem(attrs, body)
+            if problem is not None:
+                out.append(f"{rel(path)}: an inline script {problem}")
                 continue
             if body.strip():
                 where = rel(path) + (f" (<script{attrs}>)" if attrs.strip() else "")
@@ -617,7 +614,11 @@ MEDIA_RE_BRACE = re.compile(
 # here is standard library only, on purpose, so there is nothing to pin and
 # nothing to go stale. Comment lines are stripped first so prose mentioning a
 # path cannot inflate the count.
-HARNESS_STEP_RE = re.compile(r"python3\s+(tests/\S+\.py)")
+# `(?!\S)` is load-bearing. Without it, greedy \S+ backtracks to find any
+# `.py` substring, so `tests/foo.pyx` and `tests/foo.py_disabled` both captured
+# as `tests/foo.py` - a regex disagreeing with reality, in the counter that
+# exists to stop a document disagreeing with reality.
+HARNESS_STEP_RE = re.compile(r"python3\s+(tests/\S+\.py)(?!\S)")
 YAML_COMMENT_RE = re.compile(r"^\s*#.*$", re.M)
 BOARD = "docs/big-board.html"
 

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -33,6 +33,10 @@ WHAT THIS DELIBERATELY DOES NOT DO, so "checked" is not overclaimed:
     nothing else. It is not a CSS parser. Where it cannot locate a block it
     says so as its own failure rather than reporting the empty result as a
     hundred colour mismatches.
+  - It compares values, and separately checks that every colour in the base
+    :root has a variant in each override. It does not check that any of those
+    values are *good* - a theme where every colour is correct-by-this-file and
+    unreadable on its ground passes here. Look at the page.
 
     python3 tests/docs/artifact_test.py
 
@@ -252,14 +256,96 @@ def body_at(text: str, brace_index: int) -> str:
 
 
 def media_spans(text: str) -> list[tuple[int, int]]:
+    """Where the prefers-color-scheme blocks are, so the base :root search can
+    step over the one nested inside them.
+
+    A malformed block raises rather than being skipped. The first version
+    swallowed it — and the consequence was specific: an unreadable @media block
+    is not excluded from the search, so the `:root` inside it can be picked up
+    as the base and every comparison after that is against the wrong palette.
+    A file that says elsewhere "this is a failure of this check, not a colour
+    mismatch" does not get to have a silent `except: pass` in it.
+    """
     spans = []
     for m in MEDIA_RE.finditer(text):
         open_i = text.index("{", m.end())
-        try:
-            spans.append((open_i, open_i + len(body_at(text, open_i))))
-        except BlockNotFound:
-            pass
+        spans.append((open_i, open_i + len(body_at(text, open_i))))
     return spans
+
+
+# A value that names a colour. Used to tell a token that *should* have a theme
+# variant from one that legitimately does not.
+COLOUR_RE = re.compile(r"^(#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|color-mix\()")
+
+# Colour tokens that are deliberately the same in every theme. Empty today.
+# Pinned as an explicit list rather than inferred, on the same reasoning as
+# KEVIN_TOOLS in tests/workflow/kevin_scope_test.py: an exemption should be a
+# visible, deliberate edit that a reader can question, not a gap that a
+# heuristic quietly opens. Adding to this is a claim that the colour reads
+# correctly on both grounds, which is a thing to check by looking.
+THEME_INVARIANT: set[str] = set()
+
+
+def check_every_colour_themes() -> list[str]:
+    """A colour declared in the base :root must appear in every override block.
+
+    This is the check that was missing, and its absence was not an oversight in
+    the ordinary sense - it was a false negative *by construction*.
+    check_theme_parity compares the tokens the override blocks happen to name,
+    so a variable declared once in the base and omitted from all three
+    overrides was invisible to it. The harness would report "themes agree by
+    both routes" for a document where an entire colour never themed at all.
+
+    It shipped that way, and `--ultraviolet` in the calibration brief was
+    exactly it: eight of nine spectrum bands lifted for dark, one stayed put,
+    and the check written to catch theme drift said everything agreed.
+
+    Fonts, measures and radii are not colours and are not expected to theme,
+    which is what makes the rule statable without a hand-maintained list of
+    everything in the file.
+    """
+    out = []
+    for path in html_files():
+        text = read(path)
+        try:
+            base = tokens(block(text, BASE_ROOT_RE, outside_media=True))
+        except BlockNotFound:
+            continue  # check_theme_parity reports this; not doubled here
+
+        overrides: dict[str, dict[str, str]] = {}
+        if MEDIA_RE.search(text):
+            try:
+                name = MEDIA_RE.search(text).group(1).lower()
+                overrides[f"prefers-color-scheme:{name}"] = tokens(
+                    block(text, MEDIA_RE_BRACE))
+            except BlockNotFound:
+                pass
+        for name in ("light", "dark"):
+            try:
+                overrides[f'data-theme="{name}"'] = tokens(
+                    block(text, re.compile(THEME_RE.format(name=name))))
+            except BlockNotFound:
+                pass
+
+        if not overrides:
+            continue
+
+        for key, value in sorted(base.items()):
+            if not COLOUR_RE.match(value) or key in THEME_INVARIANT:
+                continue
+            absent = [where for where, toks in overrides.items() if key not in toks]
+            if len(absent) == len(overrides):
+                out.append(
+                    f"{rel(path)}: {key} is a colour ({value}) declared only in "
+                    "the base :root — it never themes, while its neighbours do. "
+                    "Give it a variant in each override, or add it to "
+                    "THEME_INVARIANT here and say why.")
+            elif absent:
+                out.append(
+                    f"{rel(path)}: {key} themes in some blocks but is missing "
+                    f"from {', '.join(absent)} — it will fall back to the base "
+                    f"value ({value}) there while its neighbours change.")
+    return out
 
 
 def block(text: str, pattern: re.Pattern[str], *, outside_media: bool = False) -> str:
@@ -387,7 +473,8 @@ def main() -> int:
               "check that passes because it found nothing to check.")
         return 1
 
-    failures = check_parses() + check_shared_widget() + check_theme_parity()
+    failures = (check_parses() + check_shared_widget()
+                + check_theme_parity() + check_every_colour_themes())
 
     if failures:
         print("docs artifact test: FAILED")
@@ -396,7 +483,7 @@ def main() -> int:
         return 1
 
     print(f"docs artifact test: {len(files)} documents parse whole, "
-          "one shared widget, themes agree by both routes")
+          "one shared widget, every colour themes, both routes agree")
     return 0
 
 

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -401,7 +401,14 @@ def declarations(css: str) -> list[str]:
     return parts
 
 
-MEDIA_RE = re.compile(r"@media\s*\(\s*prefers-color-scheme\s*:\s*(\w+)\s*\)", re.I)
+# Compound queries, either ordering. The first version required
+# `@media (prefers-color-scheme: X)` in isolation, so
+# `@media (prefers-color-scheme: dark) and (min-width: 600px)` was detected but
+# unreadable - a false FAIL on valid CSS - and the same query with the terms
+# reversed reported "no prefers-color-scheme query" while looking straight at
+# one. Neither was the silent skip it was reported as, and both were wrong.
+MEDIA_RE = re.compile(
+    r"@media[^{]*?prefers-color-scheme\s*:\s*(\w+)[^{]*", re.I)
 BASE_ROOT_RE = re.compile(r":root\s*\{")
 THEME_RE = r':root\s*\[\s*data-theme\s*=\s*["\']{name}["\']\s*\]\s*\{{'
 
@@ -486,6 +493,7 @@ class ThemeBlocks:
                              f'the data-theme="{name}" block', quiet=True)
             for name in ("light", "dark")
         }
+        self.errors += self.presence_errors()
 
     def _read(self, pattern, what: str, *, outside_media: bool = False,
               quiet: bool = False) -> dict[str, str] | None:
@@ -502,6 +510,39 @@ class ThemeBlocks:
                     f"not be read ({exc}). This is a failure of this check, "
                     "not a colour mismatch.")
             return None
+
+    def presence_errors(self) -> list[str]:
+        """Structure that is present in the text but unreadable must be LOUD.
+
+        The strict selector patterns are how blocks get read, and anything they
+        do not match falls out of detection entirely - which is a silent skip,
+        the failure this file exists to remove. Two shapes were found that way:
+        `:root[data-theme="light"], .foo { }` and `html[data-theme="light"]`
+        both parsed as "this document does not theme" and exited 0.
+
+        Rather than widening the patterns until they cover every selector
+        anyone might write - which is how the script regex accumulated three
+        defects - this asks a cruder question: does the substring appear? If it
+        does and nothing was read, say so. A checker that cannot read a
+        construct should refuse it, not ignore it.
+        """
+        out = []
+        if ("prefers-color-scheme" in self.text.lower()
+                and self.media is None):
+            out.append(
+                f"{rel(self.path, self.repo)}: the text contains "
+                "`prefers-color-scheme` but no block this check can read. It "
+                "is themed in a shape this harness does not understand, which "
+                "is refused rather than skipped.")
+        for name in ("light", "dark"):
+            if (re.search(rf'data-theme\s*=\s*["\']?{name}', self.text, re.I)
+                    and self.themed.get(name) is None):
+                out.append(
+                    f"{rel(self.path, self.repo)}: the text contains "
+                    f'`data-theme={name}` but no `:root[data-theme="{name}"]` '
+                    "block this check can read - a combined selector or a "
+                    "different element scope. Refused rather than skipped.")
+        return out
 
     def overrides(self) -> dict[str, dict[str, str]]:
         """The readable override blocks, labelled as a reader would name them."""
@@ -714,7 +755,7 @@ def check_theme_parity(all_blocks: list[ThemeBlocks], repo: Path) -> list[str]:
 
 # The media query and its opening brace, so `block` can find the body.
 MEDIA_RE_BRACE = re.compile(
-    r"@media\s*\(\s*prefers-color-scheme\s*:\s*\w+\s*\)\s*\{", re.I)
+    r"@media[^{]*?prefers-color-scheme\s*:\s*\w+[^{]*\{", re.I)
 
 
 # Deliberately NOT anchored on `run:`. That version matched a single-line
@@ -737,6 +778,40 @@ YAML_COMMENT_RE = re.compile(r"^\s*#.*$", re.M)
 BOARD = "docs/big-board.html"
 
 
+def run_blocks(yaml_text: str) -> str:
+    """Just the shell of every `run:` step, joined.
+
+    The counter used to scan the whole file with only whole-line comments
+    stripped, so a step named `run tests/ghost_test.py nightly` was read as an
+    uncountable invocation and failed the build over prose. Restricting the
+    scan to what actually executes is the difference between "this workflow
+    runs a test I cannot count" and "this workflow mentions a filename".
+
+    Not a YAML parser - it understands `run:` inline and `run: |` block
+    scalars, which is what checks.yml uses. Anything else contributes nothing,
+    and the uncountable-step guard below is what makes that loud.
+    """
+    out, lines = [], yaml_text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.match(r"^(\s*)(?:-\s*)?run:\s*(.*)$", lines[i])
+        if not m:
+            i += 1
+            continue
+        indent, inline = len(m.group(1)), m.group(2).strip()
+        if inline in ("|", ">", "|-", ">-", "|+", ">+"):
+            i += 1
+            while i < len(lines):
+                if lines[i].strip() and (len(lines[i]) - len(lines[i].lstrip())) <= indent:
+                    break
+                out.append(lines[i])
+                i += 1
+        else:
+            out.append(inline)
+            i += 1
+    return "\n".join(out)
+
+
 def check_board_harness_count(repo: Path) -> list[str]:
     """The board's headline harness count must match what CI actually runs.
 
@@ -755,7 +830,7 @@ def check_board_harness_count(repo: Path) -> list[str]:
     if not board.exists() or not workflow.exists():
         return []
 
-    body = YAML_COMMENT_RE.sub("", read(workflow))
+    body = run_blocks(YAML_COMMENT_RE.sub("", read(workflow)))
     actual = sorted(set(HARNESS_STEP_RE.findall(body)))
 
     # Anything under tests/ that this counter cannot attribute to a

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""The documents under docs/ are checked, not vouched for.
+
+Three claims were being made about `docs/big-board.html` and
+`docs/csi/shodann/calibration-brief.html` in a pull request description, each
+one true at the time and none of them enforced:
+
+    "both parse with no unclosed or mismatched tags"
+    "the widget is byte-identical in both files"
+    the palette is restated three times per file and must agree
+
+A review named the double standard exactly. `.claude/agents/shodann.md` and
+`.claude/skills/shodann-voice/SKILL.md` are also two copies expected to move
+together, and they got a version stamp and a lint check *because comparing
+bytes by hand was judged insufficient*. These two got a comment. The comment
+even explains that two earlier copies of the same widget had already diverged
+into an accessible one and a not-quite one — a note about drift, holding the
+line against drift, by itself.
+
+So this is that check. It is deliberately persona-unaware: `floor_test.py` is
+scoped to `.claude/` on purpose, because `docs/csi/ROSTER.md` describes the
+shared-base arrangement without being one and would false-positive if swept in.
+Nothing here reads prose. It checks structure only.
+
+    python3 tests/docs/artifact_test.py
+
+Standard library only.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DOCS = REPO / "docs"
+
+# Elements with no closing tag. A hand-written list rather than a dependency;
+# if one is missing the parser reports a false unclosed tag, which fails loudly
+# rather than passing quietly.
+VOID = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+}
+
+REQUIRED_SCAFFOLD = (
+    "<!DOCTYPE html>",
+    '<meta charset="utf-8">',
+    "<body>",
+    "</html>",
+)
+
+
+class Balance(HTMLParser):
+    """Tag balance only. Not a validator, and does not pretend to be one."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[tuple[str, int]] = []
+        self.errors: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        if tag not in VOID:
+            self.stack.append((tag, self.getpos()[0]))
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        pass  # self-closing, balanced by construction
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self.stack:
+            self.errors.append(f"line {self.getpos()[0]}: stray </{tag}>")
+            return
+        open_tag, line = self.stack[-1]
+        if open_tag == tag:
+            self.stack.pop()
+        else:
+            self.errors.append(
+                f"line {self.getpos()[0]}: </{tag}> closes <{open_tag}> "
+                f"opened on line {line}"
+            )
+
+
+def html_files() -> list[Path]:
+    return sorted(DOCS.rglob("*.html"))
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(REPO))
+
+
+def check_parses() -> list[str]:
+    """Every document is a whole document, and its tags balance.
+
+    The scaffolding half exists because both of these shipped as *fragments*
+    first: authored as embedded artifacts, where the host supplies the doctype
+    and head. Opened from disk that is quirks mode with the encoding
+    unspecified. Correct where they were rendered, wrong in a repository.
+    """
+    out = []
+    for path in html_files():
+        text = read(path)
+        for needed in REQUIRED_SCAFFOLD:
+            if needed not in text:
+                out.append(f"{rel(path)}: missing {needed!r} — a fragment, not "
+                           "a document. It will parse in quirks mode.")
+        parser = Balance()
+        parser.feed(text)
+        for err in parser.errors:
+            out.append(f"{rel(path)}: {err}")
+        for tag, line in parser.stack:
+            out.append(f"{rel(path)}: <{tag}> opened on line {line}, never closed")
+    return out
+
+
+SCRIPT_RE = re.compile(r"<script>(.*?)</script>", re.S)
+
+
+def check_shared_widget() -> list[str]:
+    """Every inline script under docs/ is the same script.
+
+    Today that is the tab widget, in two files. The rule is stated as "all of
+    them agree" rather than "these two agree" so that a third document cannot
+    quietly introduce a third variant — which is the precise way the previous
+    two copies diverged.
+
+    If a document ever legitimately needs a *different* script, this check is
+    the thing that must be reopened and argued with, on purpose.
+    """
+    scripts: dict[str, list[Path]] = {}
+    for path in html_files():
+        for body in SCRIPT_RE.findall(read(path)):
+            if body.strip():
+                scripts.setdefault(body, []).append(path)
+
+    if len(scripts) <= 1:
+        return []
+
+    out = ["inline scripts under docs/ have diverged; they are meant to be one "
+           "widget, pasted rather than shared:"]
+    for body, paths in scripts.items():
+        first = next((ln.strip() for ln in body.splitlines() if ln.strip()), "")
+        out.append(f"    {len(body)} chars in {', '.join(rel(p) for p in paths)}"
+                   f"  — starts {first[:60]!r}")
+    out.append("    Extract it, or make them identical again. A comment asking "
+               "for this is what failed last time.")
+    return out
+
+
+DECL_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;]+);")
+
+
+def block_after(text: str, opener: str) -> str | None:
+    """The brace-balanced body following `opener`. None if absent."""
+    i = text.find(opener)
+    if i < 0:
+        return None
+    i = text.index("{", i)
+    depth, j = 0, i
+    while j < len(text):
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[i + 1:j]
+        j += 1
+    return None
+
+
+def tokens(block: str | None) -> dict[str, str]:
+    if block is None:
+        return {}
+    return {m.group(1): m.group(2).strip() for m in DECL_RE.finditer(block)}
+
+
+def check_theme_parity() -> list[str]:
+    """The two ways of reaching a theme must agree.
+
+    A viewer's OS preference arrives as `prefers-color-scheme`; their explicit
+    toggle arrives as `data-theme` on the root and has to beat the media query.
+    That means the palette is written twice per theme, by construction — and
+    nothing stops the two from drifting apart, at which case flipping the
+    toggle changes colours that flipping the OS setting does not.
+
+    The two documents use opposite conventions — one has a dark base with a
+    light media query, the other the reverse — so this checks the invariant
+    that holds either way rather than a fixed layout.
+    """
+    out = []
+    for path in html_files():
+        text = read(path)
+        base = tokens(block_after(text, "\n  :root {"))
+        themed = {
+            name: tokens(block_after(text, f':root[data-theme="{name}"]'))
+            for name in ("light", "dark")
+        }
+        if not any(themed.values()):
+            continue
+
+        media = None
+        for name in ("light", "dark"):
+            if f"@media (prefers-color-scheme: {name})" in text:
+                media = (name, tokens(block_after(
+                    text, f"@media (prefers-color-scheme: {name})")))
+        if media is None:
+            out.append(f"{rel(path)}: has data-theme blocks but no "
+                       "prefers-color-scheme query; the OS preference is ignored")
+            continue
+
+        media_name, media_tokens = media
+        # 1. media(T) and [data-theme=T] are the same theme, reached two ways.
+        for key in sorted(set(media_tokens) | set(themed[media_name])):
+            a, b = media_tokens.get(key), themed[media_name].get(key)
+            if a != b:
+                out.append(
+                    f"{rel(path)}: {key} is {a!r} under "
+                    f"prefers-color-scheme:{media_name} but {b!r} under "
+                    f'data-theme="{media_name}" — the toggle and the OS '
+                    "preference would disagree")
+
+        # 2. The base :root carries the other theme; [data-theme=other] must
+        #    restate it exactly. Only tokens the theme block names are compared,
+        #    because :root also holds type and layout tokens that are not themed.
+        other = "dark" if media_name == "light" else "light"
+        for key, want in sorted(themed[other].items()):
+            got = base.get(key)
+            if got != want:
+                out.append(
+                    f"{rel(path)}: {key} is {got!r} in the base :root but "
+                    f'{want!r} under data-theme="{other}" — these are the same '
+                    "theme and must match")
+    return out
+
+
+def main() -> int:
+    if not DOCS.is_dir():
+        print("docs artifact test: FAILED")
+        print("  docs/ is missing; this check cannot run, which is a failure "
+              "rather than a pass.")
+        return 1
+
+    files = html_files()
+    if not files:
+        print("docs artifact test: FAILED")
+        print("  no HTML under docs/. If the documents were removed on purpose, "
+              "remove this harness in the same change rather than leaving a "
+              "check that passes because it found nothing to check.")
+        return 1
+
+    failures = check_parses() + check_shared_widget() + check_theme_parity()
+
+    if failures:
+        print("docs artifact test: FAILED")
+        for line in failures:
+            print(f"  {line}")
+        return 1
+
+    print(f"docs artifact test: {len(files)} documents parse whole, "
+          "one shared widget, themes agree by both routes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -212,6 +212,19 @@ def check_parses() -> list[str]:
 SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.S | re.I)
 
 
+def comparable_script(attrs: str, body: str) -> bool:
+    """Whether this script is one the widget comparison can speak about.
+
+    check_shared_widget skips external and `<!--`-bearing scripts; main()'s
+    success line counts inline widgets. Two filters, one definition - they are
+    not reachable out of step today only because the check runs first. Sharing
+    the predicate means a reordering cannot make the count and the comparison
+    disagree.
+    """
+    return ("src=" not in attrs.lower() and "<!--" not in body
+            and bool(body.strip()))
+
+
 def check_shared_widget() -> list[str]:
     """Every inline script under docs/ is the same script.
 
@@ -365,7 +378,17 @@ def media_spans(text: str) -> list[tuple[int, int]]:
     """
     spans = []
     for m in MEDIA_RE.finditer(text):
-        open_i = text.index("{", m.end())
+        # `.index` raised a bare ValueError when a media query had no opening
+        # brace after it. That escaped _read(), which only catches
+        # BlockNotFound, and killed main() with a raw traceback - in the file
+        # whose stated purpose is to fail with a path and a reason instead of
+        # "failing loudly about the wrong thing". Same class as the bug it
+        # describes, in the function that describes it.
+        open_i = text.find("{", m.end())
+        if open_i < 0:
+            raise BlockNotFound(
+                f"@media (prefers-color-scheme: {m.group(1)}) has no opening "
+                "brace after it")
         spans.append((open_i, open_i + len(body_at(text, open_i))))
     return spans
 
@@ -470,10 +493,10 @@ def has_theming(text: str) -> bool:
 class ThemeBlocks:
     """Every theme block in one document, read once.
 
-    Finding 2 on #42: check_theme_parity and check_every_colour_themes each
+    check_theme_parity and check_every_colour_themes each
     re-derived the base :root, the media block and the two data-theme blocks,
-    with their own try/except wording around each. The mutual-deferral bug that
-    round 6 found came from exactly that shape - one function's error handling
+    with their own try/except wording around each. The mutual-deferral bug came
+    from exactly that shape - one function's error handling
     silently depending on the other's, under a combination neither covered.
     Fixing the one combination while leaving the duplication in place invites
     the next one, so the reading happens once and both checks consume it.
@@ -583,7 +606,19 @@ MEDIA_RE_BRACE = re.compile(
     r"@media\s*\(\s*prefers-color-scheme\s*:\s*\w+\s*\)\s*\{", re.I)
 
 
-HARNESS_STEP_RE = re.compile(r"run:\s*python3\s+(tests/\S+\.py)")
+# Deliberately NOT anchored on `run:`. That version matched a single-line
+# `run: python3 <path>` only, so a `run: |` block scalar, a chained
+# `a && b`, or an added flag silently dropped out of the count - and the
+# failure surfaced as this check blaming big-board.html for a number that was
+# actually wrong because of the regex. Checked against a realistic sample:
+# anchored found 1 of 3, unanchored found 3 of 3.
+#
+# yaml.safe_load would be the better tool and is not available: every harness
+# here is standard library only, on purpose, so there is nothing to pin and
+# nothing to go stale. Comment lines are stripped first so prose mentioning a
+# path cannot inflate the count.
+HARNESS_STEP_RE = re.compile(r"python3\s+(tests/\S+\.py)")
+YAML_COMMENT_RE = re.compile(r"^\s*#.*$", re.M)
 BOARD = "docs/big-board.html"
 
 
@@ -605,7 +640,8 @@ def check_board_harness_count() -> list[str]:
     if not board.exists() or not workflow.exists():
         return []
 
-    actual = sorted(set(HARNESS_STEP_RE.findall(read(workflow))))
+    body = YAML_COMMENT_RE.sub("", read(workflow))
+    actual = sorted(set(HARNESS_STEP_RE.findall(body)))
     text = read(board)
     m = re.search(r'data-harness-count="(\d+)"', text)
     if not m:
@@ -638,7 +674,7 @@ def main() -> int:
     # Read once, here. Both theme checks used to build their own ThemeBlocks,
     # and the errors were emitted by whichever of them happened to run - a
     # coupling held by a comment, in a file whose second half is a record of
-    # comment-held couplings failing. Round 6 found one of those; leaving the
+    # comment-held couplings failing. This file has already had one of those; leaving the
     # shape in place invites the next. main() now owns the read and the
     # reporting, so removing or reordering either check cannot make an
     # unreadable block go quiet.
@@ -663,7 +699,7 @@ def main() -> int:
     # claim like any other.
     n_widgets = len({body for path in files
                      for attrs, body in SCRIPT_RE.findall(read(path))
-                     if body.strip() and "src=" not in attrs.lower()})
+                     if comparable_script(attrs, body)})
     widget = ("no inline widget" if n_widgets == 0
               else f"{n_widgets} shared widget")
     print(f"docs artifact test: {len(files)} documents parse whole, "

--- a/tests/docs/artifact_test.py
+++ b/tests/docs/artifact_test.py
@@ -53,6 +53,16 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 DOCS = REPO / "docs"
 
+# The parents[2] above is a depth assumption, and a wrong one would not raise -
+# it would point DOCS somewhere with no HTML in it, and main()'s empty-set
+# branch would report "no HTML under docs/" as though the documents had been
+# deleted. Anchored so a moved file says what actually happened.
+if not (REPO / ".git").exists() and not (REPO / "tests" / "docs").is_dir():
+    raise SystemExit(
+        f"artifact_test.py: computed repository root {REPO} does not look like "
+        "one. This file moved and parents[2] no longer reaches the root; fix "
+        "the depth rather than letting the checks run against the wrong tree.")
+
 # Elements with no closing tag. A hand-written list rather than a dependency;
 # if one is missing the parser reports a false unclosed tag, which fails loudly
 # rather than passing quietly.
@@ -87,8 +97,17 @@ class ArtifactDocument(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs) -> None:
         a = {k.lower(): (v or "") for k, v in attrs}
-        if tag == "meta" and a.get("charset", "").strip().lower() == "utf-8":
-            self.charset = True
+        # Both spellings. <meta charset> is the HTML5 form and what both
+        # current documents use; the http-equiv form is still valid and a
+        # document using it is correct, so rejecting it would be this file
+        # failing a correct input - which it has already done once, over
+        # <!doctype html>.
+        if tag == "meta":
+            if a.get("charset", "").strip().lower() == "utf-8":
+                self.charset = True
+            elif (a.get("http-equiv", "").strip().lower() == "content-type"
+                  and "utf-8" in a.get("content", "").lower()):
+                self.charset = True
         if tag == "body":
             self.body = True
         if tag == "html":
@@ -362,51 +381,15 @@ def check_every_colour_themes() -> list[str]:
     """
     out = []
     for path in html_files():
-        text = read(path)
-        if not has_theming(text):
+        blocks = ThemeBlocks(path)
+        out += blocks.errors
+        if not blocks.themes or blocks.base is None:
             continue
-
-        # Reported here rather than deferred. The previous version said
-        # `except BlockNotFound: continue  # check_theme_parity reports this`,
-        # which was true only when a data-theme block also existed -
-        # check_theme_parity short-circuits before reading the base when there
-        # is none. So a document with a prefers-color-scheme query, no
-        # data-theme block, and an unreadable base :root passed BOTH checks and
-        # printed "every colour themes, both routes agree". Reproduced as a
-        # real file before this was changed, not reasoned about.
-        #
-        # Two functions each deferring to the other, through a comment
-        # promising the other would catch it. That is the third time in this
-        # file that a comment has been asked to do a check's job, and it is
-        # what the file is about.
-        try:
-            base = tokens(block(text, BASE_ROOT_RE, outside_media=True))
-        except BlockNotFound as exc:
-            out.append(f"{rel(path)}: this document themes, but its base :root "
-                       f"could not be read ({exc}). This is a failure of this "
-                       "check, not a colour mismatch.")
-            continue
-
-        overrides: dict[str, dict[str, str]] = {}
-        media = MEDIA_RE.search(text)
-        if media:
-            try:
-                overrides[f"prefers-color-scheme:{media.group(1).lower()}"] = (
-                    tokens(block(text, MEDIA_RE_BRACE)))
-            except BlockNotFound as exc:
-                out.append(f"{rel(path)}: could not read the "
-                           f"prefers-color-scheme block ({exc}).")
-        for name in ("light", "dark"):
-            try:
-                overrides[f'data-theme="{name}"'] = tokens(
-                    block(text, re.compile(THEME_RE.format(name=name))))
-            except BlockNotFound:
-                pass
-
+        overrides = blocks.overrides()
         if not overrides:
             continue
 
-        for key, value in sorted(base.items()):
+        for key, value in sorted(blocks.base.items()):
             if not COLOUR_RE.match(value) or key in THEME_INVARIANT:
                 continue
             absent = [where for where, toks in overrides.items() if key not in toks]
@@ -463,6 +446,63 @@ def has_theming(text: str) -> bool:
         re.search(THEME_RE.format(name=n), text) for n in ("light", "dark"))
 
 
+class ThemeBlocks:
+    """Every theme block in one document, read once.
+
+    Finding 2 on #42: check_theme_parity and check_every_colour_themes each
+    re-derived the base :root, the media block and the two data-theme blocks,
+    with their own try/except wording around each. The mutual-deferral bug that
+    round 6 found came from exactly that shape - one function's error handling
+    silently depending on the other's, under a combination neither covered.
+    Fixing the one combination while leaving the duplication in place invites
+    the next one, so the reading happens once and both checks consume it.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.text = read(path)
+        self.errors: list[str] = []
+        self.themes = has_theming(self.text)
+
+        self.base = self._read(BASE_ROOT_RE, "the base :root", outside_media=True)
+        m = MEDIA_RE.search(self.text)
+        self.media_name = m.group(1).lower() if m else None
+        self.media = (self._read(MEDIA_RE_BRACE,
+                                 f"the prefers-color-scheme:{self.media_name} block")
+                      if m else None)
+        self.themed = {
+            name: self._read(re.compile(THEME_RE.format(name=name)),
+                             f'the data-theme="{name}" block', quiet=True)
+            for name in ("light", "dark")
+        }
+
+    def _read(self, pattern, what: str, *, outside_media: bool = False,
+              quiet: bool = False) -> dict[str, str] | None:
+        try:
+            return tokens(block(self.text, pattern, outside_media=outside_media))
+        except BlockNotFound as exc:
+            # `quiet` covers the blocks a document may legitimately not have.
+            # Everything else is reported as a failure OF THIS CHECK, in those
+            # words, because an unreadable block used to surface as a page of
+            # invented colour mismatches.
+            if not quiet and self.themes:
+                self.errors.append(
+                    f"{rel(self.path)}: this document themes, but {what} could "
+                    f"not be read ({exc}). This is a failure of this check, "
+                    "not a colour mismatch.")
+            return None
+
+    def overrides(self) -> dict[str, dict[str, str]]:
+        """The readable override blocks, labelled as a reader would name them."""
+        out = {}
+        if self.media is not None:
+            out[f"prefers-color-scheme:{self.media_name}"] = self.media
+        for name, toks in self.themed.items():
+            if toks is not None:
+                out[f'data-theme="{name}"'] = toks
+        return out
+
+
 def check_theme_parity() -> list[str]:
     """The two ways of reaching a theme must agree.
 
@@ -479,45 +519,28 @@ def check_theme_parity() -> list[str]:
     """
     out = []
     for path in html_files():
-        text = read(path)
-        themed = {}
-        for name in ("light", "dark"):
-            pattern = re.compile(THEME_RE.format(name=name))
-            try:
-                themed[name] = tokens(block(text, pattern))
-            except BlockNotFound:
-                themed[name] = None
+        blocks = ThemeBlocks(path)
+        # Errors are reported by check_every_colour_themes, which reads the same
+        # blocks. Not repeated here - but note this is a claim about a shared
+        # object, not two functions promising each other something. If that
+        # function is ever removed, this needs its own `out += blocks.errors`.
+        if not any(v for v in blocks.themed.values()):
+            continue  # no theme toggle; nothing can disagree
 
-        if not any(v for v in themed.values()):
-            continue  # a document with no theme toggle has nothing to disagree
-
-        media = MEDIA_RE.search(text)
-        if media is None:
+        if blocks.media_name is None:
             out.append(f"{rel(path)}: has data-theme blocks but no "
                        "prefers-color-scheme query; the OS preference is ignored")
             continue
-        media_name = media.group(1).lower()
+        media_name = blocks.media_name
         other = "dark" if media_name == "light" else "light"
 
-        try:
-            media_tokens = tokens(block(text, MEDIA_RE_BRACE))
-        except BlockNotFound as exc:
-            out.append(f"{rel(path)}: could not read the "
-                       f"prefers-color-scheme:{media_name} block ({exc}). "
-                       "This is a failure of this check, not a colour mismatch.")
-            continue
-
-        for name in (media_name, other):
-            if themed.get(name) is None:
-                out.append(f"{rel(path)}: could not read the "
-                           f'data-theme="{name}" block. This is a failure of '
-                           "this check, not a colour mismatch.")
-        if themed.get(media_name) is None or themed.get(other) is None:
-            continue
+        if blocks.media is None or blocks.themed.get(media_name) is None \
+                or blocks.themed.get(other) is None or blocks.base is None:
+            continue  # unreadable; already reported as this check's own failure
 
         # 1. media(T) and [data-theme=T] are the same theme, reached two ways.
-        for key in sorted(set(media_tokens) | set(themed[media_name])):
-            a, b = media_tokens.get(key), themed[media_name].get(key)
+        for key in sorted(set(blocks.media) | set(blocks.themed[media_name])):
+            a, b = blocks.media.get(key), blocks.themed[media_name].get(key)
             if a != b:
                 out.append(
                     f"{rel(path)}: {key} is {a!r} under "
@@ -528,15 +551,8 @@ def check_theme_parity() -> list[str]:
         # 2. The base :root carries the other theme; [data-theme=other] must
         #    restate it exactly. Only tokens the theme block names are compared,
         #    because :root also holds type and layout tokens that are not themed.
-        try:
-            base = tokens(block(text, BASE_ROOT_RE, outside_media=True))
-        except BlockNotFound as exc:
-            out.append(f"{rel(path)}: could not read the base :root block "
-                       f"({exc}). This is a failure of this check, not a "
-                       "colour mismatch.")
-            continue
-        for key, want in sorted(themed[other].items()):
-            got = base.get(key)
+        for key, want in sorted(blocks.themed[other].items()):
+            got = blocks.base.get(key)
             if got != want:
                 out.append(
                     f"{rel(path)}: {key} is {got!r} in the base :root but "
@@ -574,8 +590,18 @@ def main() -> int:
             print(f"  {line}")
         return 1
 
+    # Derived, not asserted. The previous version printed "one shared widget"
+    # unconditionally on success, while check_shared_widget only requires that
+    # there be no MORE than one - so three documents with no scripts at all
+    # would have reported a widget that does not exist. A success line is a
+    # claim like any other.
+    n_widgets = len({body for path in files
+                     for attrs, body in SCRIPT_RE.findall(read(path))
+                     if body.strip() and "src=" not in attrs.lower()})
+    widget = ("no inline widget" if n_widgets == 0
+              else f"{n_widgets} shared widget")
     print(f"docs artifact test: {len(files)} documents parse whole, "
-          "one shared widget, every colour themes, both routes agree")
+          f"{widget}, every colour themes, both routes agree")
     return 0
 
 

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -188,6 +188,20 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
                                      '--sep: ";";\n    --sans: system-ui, sans-serif;'))},
      False, ""),
 
+    # GOOD_CSS had no comments, so extracting the shared CSS scanner broke
+    # comment handling and this file said nothing - the two real documents
+    # caught it. A meta-test whose fixtures are simpler than the real input
+    # tests the fixtures.
+    ("a comment before the first declaration does not eat it",
+     {"a.html": doc(GOOD_CSS.replace("  :root {",
+                                     "  :root {\n    /* a note; with a semicolon and a { brace */"))},
+     False, ""),
+
+    ("a comment between declarations does not eat the next one",
+     {"a.html": doc(GOOD_CSS.replace("--ink: #E7E9ED;",
+                                     "--ink: #E7E9ED;\n    /* mid-block */"))},
+     False, ""),
+
     ("a reformatted :root with no indent is still found",
      {"a.html": doc(GOOD_CSS.replace("\n  :root {", "\n:root{"))}, False, ""),
 
@@ -225,8 +239,37 @@ def run_against(files: dict[str, str]) -> tuple[int, str]:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def check_theme_invariant_exemption() -> list[str]:
+    """The exemption path must actually exempt.
+
+    THEME_INVARIANT ships empty with a paragraph of justification and no
+    exercised branch. An exemption nobody has ever taken is a promise, and the
+    first person to need it would find out at that moment whether it works.
+    """
+    files = {"a.html": doc(GOOD_CSS.replace(
+        "--ink: #E7E9ED;\n    --sans",
+        "--ink: #E7E9ED;\n    --brand: #A855F7;\n    --sans"))}
+
+    code, _ = run_against(files)
+    if code == 0:
+        return ["an unthemed colour passed even before the exemption was "
+                "applied; this case proves nothing as written"]
+
+    original = A.THEME_INVARIANT
+    A.THEME_INVARIANT = {"--brand"}
+    try:
+        code, output = run_against(files)
+    finally:
+        A.THEME_INVARIANT = original
+    if code != 0:
+        return [f"THEME_INVARIANT did not suppress the finding for an exempted "
+                f"token; the exemption path does not work. output: "
+                f"{output.strip()[:200]}"]
+    return []
+
+
 def main() -> int:
-    failures = []
+    failures = check_theme_invariant_exemption()
     for name, files, expect_failure, needle in CASES:
         code, output = run_against(files)
         failed = code != 0

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -30,6 +30,8 @@ Standard library only.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import shutil
 import sys
 import tempfile
@@ -252,6 +254,13 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
      "steps:\n  - run: python3 tests/a_test.py && python3 tests/b_test.py\n",
      False, ""),
 
+    # Greedy \S+ with no trailing anchor captured `tests/foo.py` out of
+    # `tests/foo.pyx`, inflating the count against a file that does not run.
+    ("a .pyx path is not counted as a .py harness",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  - run: python3 tests/a_test.py\n  - run: python3 tests/b.pyx\n",
+     False, ""),
+
     ("a path named only in a comment is not counted",
      doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
      "steps:\n  # python3 tests/ghost_test.py used to run here\n"
@@ -281,11 +290,13 @@ def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int
         real_docs, real_repo = A.DOCS, A.REPO
         A.DOCS, A.REPO = docs, tmp
         buf: list[str] = []
-        import builtins
-        original = builtins.print
-        builtins.print = lambda *a, **k: buf.append(" ".join(str(x) for x in a))
+        # contextlib.redirect_stdout rather than monkeypatching builtins.print:
+        # the stdlib primitive exists for this and does not interact oddly with
+        # a runner that also patches print.
+        sink = io.StringIO()
         try:
-            code = A.main()
+            with contextlib.redirect_stdout(sink):
+                code = A.main()
         except BaseException as exc:  # noqa: BLE001
             # A harness that dies with a traceback where it should report is
             # the failure this whole stack is about. Reverting the media_spans
@@ -293,9 +304,8 @@ def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int
             buf.append(f"the harness raised {type(exc).__name__}: {exc}")
             code = 1
         finally:
-            builtins.print = original
             A.DOCS, A.REPO = real_docs, real_repo
-        return code, "\n".join(buf)
+        return code, sink.getvalue() + "\n".join(buf)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -317,7 +317,8 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
 
 
 def run_against(files: dict[str, str], workflow: str | None = None,
-                theme_invariant: set[str] | None = None) -> tuple[int, str]:
+                theme_invariant: set[str] | None = None,
+                capture: bool = True) -> tuple[int, str]:
     """Point the harness at a scratch docs/ and capture what it reports.
 
     `workflow` writes a .github/workflows/checks.yml, so the board-count check
@@ -339,9 +340,16 @@ def run_against(files: dict[str, str], workflow: str | None = None,
         # Roots passed as arguments rather than assigned onto the module.
         # The previous version swapped A.DOCS and A.REPO and restored them in a
         # finally - correct here, and silently wrong under any parallel runner.
+        # `capture` exists because contextlib.redirect_stdout swaps sys.stdout
+        # PROCESS-WIDE. It is the right primitive for a sequential run and the
+        # wrong one inside threads, where two redirects race and output leaks -
+        # found by check_parallel_safe, which was written to prove main() is
+        # thread-safe and instead proved this capture was not. The threaded
+        # caller sets capture=False and redirects once around the whole block.
         sink = io.StringIO()
         try:
-            with contextlib.redirect_stdout(sink):
+            with contextlib.redirect_stdout(sink) if capture \
+                    else contextlib.nullcontext():
                 code = A.main(docs_root=docs, repo_root=tmp,
                               theme_invariant=theme_invariant)
         except Exception as exc:  # noqa: BLE001 - a Ctrl-C is not a finding
@@ -352,6 +360,80 @@ def run_against(files: dict[str, str], workflow: str | None = None,
         return code, sink.getvalue() + "\n".join(buf)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
+
+
+def check_colour_list_is_complete() -> list[str]:
+    """The named-colour set must stay the whole set.
+
+    A partial list was the previous version and it was the worst option: it
+    looked exhaustive while silently skipping whatever nobody thought to add.
+    Pinned by count so an accidental edit trips this rather than drifting back
+    into that shape.
+    """
+    n = len(A.CSS_NAMED_COLOURS)
+    out = []
+    if n != 148:
+        out.append(f"CSS_NAMED_COLOURS has {n} entries, not 148. If a keyword "
+                   "was added to the CSS spec, update the count with it; if one "
+                   "was dropped by accident, this is the check that noticed.")
+    for name in ("rebeccapurple", "papayawhip", "transparent"):
+        if not A.is_colour(name):
+            out.append(f"{name!r} is a colour and is_colour() says otherwise")
+    return out
+
+
+def check_exemption_is_exact() -> list[str]:
+    """Only an exact key may be exempted.
+
+    Nothing today matches by prefix or case - `key in theme_invariant` is a set
+    membership test. This pins that, so a refactor to a substring or
+    case-folded comparison cannot quietly widen every exemption.
+    """
+    files = {"a.html": doc(GOOD_CSS.replace(
+        "--ink: #E7E9ED;\n    --sans",
+        "--ink: #E7E9ED;\n    --brand-2: #A855F7;\n    --sans"))}
+    code, output = run_against(files, theme_invariant={"--brand"})
+    if code == 0:
+        return ["exempting '--brand' also suppressed '--brand-2'; the "
+                "exemption is matching by prefix rather than exactly"]
+    code, output = run_against(files, theme_invariant={"--BRAND-2"})
+    if code == 0:
+        return ["exempting '--BRAND-2' suppressed '--brand-2'; the exemption "
+                "is case-folding when it should not"]
+    return []
+
+
+def check_parallel_safe() -> list[str]:
+    """main() must not fight itself across threads.
+
+    The previous version assigned the roots onto the module and restored them
+    in a finally, with a comment claiming that removed the shared state. It did
+    not - it moved the race inside the function. Now the roots are arguments,
+    so two concurrent runs over different trees cannot see each other's. Proven
+    rather than asserted, because the claim was wrong once already.
+    """
+    import threading
+    good = {"a.html": doc(GOOD_CSS)}
+    bad = {"a.html": doc(GOOD_CSS, body="<div><p>x</p>")}
+    results: dict[str, list] = {"good": [], "bad": []}
+
+    def worker(kind, files, expect):
+        for _ in range(6):
+            code, _out = run_against(files, capture=False)
+            results[kind].append(code == expect)
+
+    # One redirect around the whole parallel section, not one per call.
+    with contextlib.redirect_stdout(io.StringIO()):
+        threads = [threading.Thread(target=worker, args=("good", good, 0)),
+                   threading.Thread(target=worker, args=("bad", bad, 1))]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+    if not all(results["good"]) or not all(results["bad"]):
+        return ["concurrent runs over different trees interfered: "
+                f"good={results['good']} bad={results['bad']}"]
+    return []
 
 
 def check_theme_invariant_exemption() -> list[str]:
@@ -397,7 +479,9 @@ def check_board_cases() -> list[str]:
 
 
 def main() -> int:
-    failures = check_theme_invariant_exemption() + check_board_cases()
+    failures = (check_theme_invariant_exemption() + check_board_cases()
+                + check_colour_list_is_complete() + check_exemption_is_exact()
+                + check_parallel_safe())
     for name, files, expect_failure, needle in CASES:
         code, output = run_against(files)
         failed = code != 0

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -12,7 +12,7 @@ can only exercise the branches those two documents happen to trigger — so an
 edit to `body_at`, `THEME_RE` or `SCRIPT_RE` that reintroduces a false pass
 would be caught by nothing.
 
-It has already shipped three defects of that kind in six rounds:
+It has already shipped three defects of that kind:
 
     a false positive   `<script>` matched bare only, so a divergent
                        `<script type="module">` was not compared at all
@@ -211,17 +211,72 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
 
     ("no documents at all is a failure, not a pass",
      {}, True, "no HTML under docs/"),
+
+    # A media query with no opening brace used to raise a bare ValueError out
+    # of media_spans and kill main() with a traceback - in the file whose whole
+    # promise is a path and a reason instead of a stack.
+    ("a media query with no opening brace reports rather than crashing",
+     {"a.html": doc("  :root { --a: #ffffff; }\n"
+                    "  @media (prefers-color-scheme: dark)\n")},
+     True, "could not be read"),
 ]
 
 
-def run_against(files: dict[str, str]) -> tuple[int, str]:
-    """Point the harness at a scratch docs/ and capture what it reports."""
+# The board-count check needs a workflow to count, so these carry one.
+# (name, board html, workflow yaml, expect_failure, needle)
+BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
+    ("a matching count passes",
+     doc(GOOD_CSS, body='<div data-harness-count="2">x</div>'),
+     "steps:\n  - run: python3 tests/a_test.py\n  - run: python3 tests/b_test.py\n",
+     False, ""),
+
+    ("a wrong count is caught",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  - run: python3 tests/a_test.py\n  - run: python3 tests/b_test.py\n",
+     True, "claims 1 harnesses; checks.yml runs 2"),
+
+    ("no count attribute at all is caught",
+     doc(GOOD_CSS, body="<div>x</div>"),
+     "steps:\n  - run: python3 tests/a_test.py\n",
+     True, "no data-harness-count"),
+
+    # The counter was anchored on `run:` and found 1 of 3 in this shape.
+    ("a run: | block scalar is counted",
+     doc(GOOD_CSS, body='<div data-harness-count="3">x</div>'),
+     ("steps:\n  - run: |\n      python3 tests/a_test.py\n"
+      "      python3 tests/b_test.py\n  - run: python3 tests/c_test.py\n"),
+     False, ""),
+
+    ("a chained command is counted",
+     doc(GOOD_CSS, body='<div data-harness-count="2">x</div>'),
+     "steps:\n  - run: python3 tests/a_test.py && python3 tests/b_test.py\n",
+     False, ""),
+
+    ("a path named only in a comment is not counted",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  # python3 tests/ghost_test.py used to run here\n"
+     "  - run: python3 tests/a_test.py\n",
+     False, ""),
+]
+
+
+def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int, str]:
+    """Point the harness at a scratch docs/ and capture what it reports.
+
+    `workflow` writes a .github/workflows/checks.yml, so the board-count check
+    can be exercised against a real file rather than only against this
+    repository's own - which is the only shape it would otherwise ever see.
+    """
     tmp = Path(tempfile.mkdtemp())
     try:
         docs = tmp / "docs"
         docs.mkdir()
         for name, content in files.items():
             (docs / name).write_text(content, encoding="utf-8")
+        if workflow is not None:
+            wf = tmp / ".github" / "workflows"
+            wf.mkdir(parents=True)
+            (wf / "checks.yml").write_text(workflow, encoding="utf-8")
 
         real_docs, real_repo = A.DOCS, A.REPO
         A.DOCS, A.REPO = docs, tmp
@@ -231,6 +286,12 @@ def run_against(files: dict[str, str]) -> tuple[int, str]:
         builtins.print = lambda *a, **k: buf.append(" ".join(str(x) for x in a))
         try:
             code = A.main()
+        except BaseException as exc:  # noqa: BLE001
+            # A harness that dies with a traceback where it should report is
+            # the failure this whole stack is about. Reverting the media_spans
+            # fix made THIS file crash rather than say which case broke.
+            buf.append(f"the harness raised {type(exc).__name__}: {exc}")
+            code = 1
         finally:
             builtins.print = original
             A.DOCS, A.REPO = real_docs, real_repo
@@ -268,8 +329,26 @@ def check_theme_invariant_exemption() -> list[str]:
     return []
 
 
+def check_board_cases() -> list[str]:
+    """The board-count check, against workflows it would otherwise never see."""
+    out = []
+    for name, board, workflow, expect_failure, needle in BOARD_CASES:
+        code, output = run_against({"big-board.html": board}, workflow=workflow)
+        failed = code != 0
+        if failed != expect_failure:
+            out.append(f"board: {name}\n    expected "
+                       f"{'a failure' if expect_failure else 'a pass'}, got "
+                       f"{'a failure' if failed else 'a pass'}\n"
+                       f"    output: {output.strip()[:300]}")
+        elif expect_failure and needle and needle not in output:
+            out.append(f"board: {name}\n    failed for the wrong reason: "
+                       f"{needle!r} not in the report\n"
+                       f"    output: {output.strip()[:300]}")
+    return out
+
+
 def main() -> int:
-    failures = check_theme_invariant_exemption()
+    failures = check_theme_invariant_exemption() + check_board_cases()
     for name, files, expect_failure, needle in CASES:
         code, output = run_against(files)
         failed = code != 0
@@ -290,8 +369,7 @@ def main() -> int:
         return 1
 
     fails = sum(1 for _, _, e, _ in CASES if e)
-    print(f"harness test: {len(CASES)} cases behave — {fails} that must fail "
-          f"do, {len(CASES) - fails} that must pass do")
+    print(f"harness test: {len(CASES)} document cases and {len(BOARD_CASES)} board-count cases behave — {fails} that must fail do")
     return 0
 
 

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import re
+import subprocess
 import shutil
 import sys
 import tempfile
@@ -41,8 +43,9 @@ from pathlib import Path
 # Loaded by explicit path rather than by putting a directory on sys.path and
 # hoping this is the `artifact_test` that gets found. There is only one today;
 # the import should not depend on that staying true.
+SOURCE = Path(__file__).resolve().parent / "artifact_test.py"
 _SPEC = importlib.util.spec_from_file_location(
-    "artifact_test", Path(__file__).resolve().parent / "artifact_test.py")
+    "artifact_test", SOURCE)
 A = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(A)
 
@@ -350,6 +353,13 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
      "steps:\n  - run: python3 tests/a_test.py\n  - run: pytest tests/b_test.py\n",
      True, "cannot read"),
 
+    ("a uses: step referencing a test path is still reported",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  - uses: ./.github/actions/run-harness\n"
+     "    with:\n      script: tests/ghost_test.py\n"
+     "  - run: python3 tests/a_test.py\n",
+     True, "cannot read"),
+
     ("a test path named in a step name is not counted as an invocation",
      doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
      "steps:\n  - name: run tests/ghost_test.py nightly\n"
@@ -410,6 +420,38 @@ def run_against(files: dict[str, str], workflow: str | None = None,
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def check_layout_guard() -> list[str]:
+    """check_layout must fire when the file is at the wrong depth.
+
+    It was the only check in artifact_test.py with no adversarial case - and
+    the most brittle, since it hard-codes a path depth. "The harness has a
+    harness" with one unverified exception is the shape this whole stack
+    exists to remove, so the exception gets a case.
+
+    Run as a subprocess from a copy at the wrong depth, because the check reads
+    __file__ and an in-process import would still see the real one.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    try:
+        # One level too shallow: <tmp>/docs/artifact_test.py, so parents[2]
+        # points above tmp and the reconstructed path cannot match.
+        wrong = tmp / "docs"
+        wrong.mkdir(parents=True)
+        shutil.copy(SOURCE, wrong / "artifact_test.py")
+        (tmp / "docs" / "x.html").write_text(doc(GOOD_CSS), encoding="utf-8")
+        proc = subprocess.run([sys.executable, str(wrong / "artifact_test.py")],
+                              capture_output=True, text=True, timeout=60)
+        if proc.returncode == 0:
+            return ["artifact_test.py run from the wrong depth exited 0; "
+                    "check_layout did not fire"]
+        if "parents[2] resolves to" not in proc.stdout + proc.stderr:
+            return ["artifact_test.py run from the wrong depth failed, but not "
+                    f"with check_layout's message: {(proc.stdout + proc.stderr).strip()[:200]}"]
+        return []
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def check_colour_list_is_complete() -> list[str]:
     """The named-colour set must stay the whole set.
 
@@ -418,8 +460,18 @@ def check_colour_list_is_complete() -> list[str]:
     Pinned by count so an accidental edit trips this rather than drifting back
     into that shape.
     """
+    # Also checked for duplicates: the frozenset would collapse a repeated
+    # keyword, so adding one and dropping another leaves the count at 148 and
+    # the set one keyword short. Counting raw tokens is what notices.
+    raw = re.search(r'CSS_NAMED_COLOURS = frozenset\("""(.*?)"""', SOURCE.read_text(),
+                    re.S).group(1).split()
     n = len(A.CSS_NAMED_COLOURS)
     out = []
+    if len(raw) != n:
+        dupes = sorted({w for w in raw if raw.count(w) > 1})
+        out.append(f"CSS_NAMED_COLOURS lists {len(raw)} keywords but holds {n}; "
+                   f"duplicated: {dupes}. A duplicate hides a dropped keyword "
+                   "from the count check below.")
     # 148 = the CSS Color Module Level 4 <named-color> keyword set. Not a
     # magic number: 147 from CSS Color 3, plus `rebeccapurple` added in Level
     # 4. `transparent` and `currentColor` are separate keywords and are handled
@@ -532,6 +584,7 @@ def check_board_cases() -> list[str]:
 
 def main() -> int:
     failures = (check_theme_invariant_exemption() + check_board_cases()
+                + check_layout_guard()
                 + check_colour_list_is_complete() + check_exemption_is_exact()
                 + check_parallel_safe())
     for name, files, expect_failure, needle in CASES:

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -31,14 +31,20 @@ Standard library only.
 from __future__ import annotations
 
 import contextlib
+import importlib.util
 import io
 import shutil
 import sys
 import tempfile
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import artifact_test as A  # noqa: E402
+# Loaded by explicit path rather than by putting a directory on sys.path and
+# hoping this is the `artifact_test` that gets found. There is only one today;
+# the import should not depend on that staying true.
+_SPEC = importlib.util.spec_from_file_location(
+    "artifact_test", Path(__file__).resolve().parent / "artifact_test.py")
+A = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(A)
 
 
 def doc(style: str = "", body: str = "<p>x</p>", script: str | None = None,
@@ -68,6 +74,28 @@ GOOD_CSS = """
   :root[data-theme="light"] { --ground: #EFEEE9; --ink: #15181D; }
   :root[data-theme="dark"] { --ground: #0E1116; --ink: #E7E9ED; }
 """
+
+COMPOUND_CSS = (
+    "  :root { --ground: #0E1116; }\n"
+    "  @media (prefers-color-scheme: light) and (min-width: 600px) {\n"
+    "    :root { --ground: #EFEEE9; }\n  }\n"
+    '  :root[data-theme="light"] { --ground: #EFEEE9; }\n'
+    '  :root[data-theme="dark"] { --ground: #0E1116; }\n'
+)
+
+COMPOUND_REVERSED_CSS = COMPOUND_CSS.replace(
+    "(prefers-color-scheme: light) and (min-width: 600px)",
+    "(min-width: 600px) and (prefers-color-scheme: light)")
+
+COMBINED_SELECTOR_CSS = (
+    "  :root { --ground: #0E1116; }\n"
+    '  :root[data-theme="light"], .foo { --ground: #EFEEE9; }\n'
+)
+
+OTHER_ELEMENT_CSS = (
+    "  :root { --ground: #0E1116; }\n"
+    '  html[data-theme="light"] { --ground: #EFEEE9; }\n'
+)
 
 WIDGET = "<script>\n  var a = 1;\n</script>"
 
@@ -214,6 +242,20 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
     ("no documents at all is a failure, not a pass",
      {}, True, "no HTML under docs/"),
 
+    ("a compound prefers-color-scheme query is read, not falsely failed",
+     {"a.html": doc(COMPOUND_CSS)}, False, ""),
+
+    ("a compound query with the terms reversed is read too",
+     {"a.html": doc(COMPOUND_REVERSED_CSS)}, False, ""),
+
+    # Both of these exited 0 before the presence guard: the selector patterns
+    # did not match, so the document read as "does not theme" and was skipped.
+    ("a combined data-theme selector is refused, not skipped",
+     {"a.html": doc(COMBINED_SELECTOR_CSS)}, True, "Refused rather than skipped"),
+
+    ("data-theme on a different element is refused, not skipped",
+     {"a.html": doc(OTHER_ELEMENT_CSS)}, True, "Refused rather than skipped"),
+
     ("an uncommon named colour still has to theme",
      {"a.html": doc(GOOD_CSS.replace("--ink: #E7E9ED;\n    --sans",
                                      "--ink: #E7E9ED;\n    --brand: rebeccapurple;\n    --sans"))},
@@ -308,6 +350,12 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
      "steps:\n  - run: python3 tests/a_test.py\n  - run: pytest tests/b_test.py\n",
      True, "cannot read"),
 
+    ("a test path named in a step name is not counted as an invocation",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  - name: run tests/ghost_test.py nightly\n"
+     "    run: python3 tests/a_test.py\n",
+     False, ""),
+
     ("a path named only in a comment is not counted",
      doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
      "steps:\n  # python3 tests/ghost_test.py used to run here\n"
@@ -372,6 +420,10 @@ def check_colour_list_is_complete() -> list[str]:
     """
     n = len(A.CSS_NAMED_COLOURS)
     out = []
+    # 148 = the CSS Color Module Level 4 <named-color> keyword set. Not a
+    # magic number: 147 from CSS Color 3, plus `rebeccapurple` added in Level
+    # 4. `transparent` and `currentColor` are separate keywords and are handled
+    # beside the set, not in it.
     if n != 148:
         out.append(f"CSS_NAMED_COLOURS has {n} entries, not 148. If a keyword "
                    "was added to the CSS spec, update the count with it; if one "

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -214,6 +214,19 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
     ("no documents at all is a failure, not a pass",
      {}, True, "no HTML under docs/"),
 
+    ("a bare <svg/> with no children self-closes",
+     {"a.html": doc(GOOD_CSS, body="<svg/><p>x</p>")}, False, ""),
+
+    ("a data-type attribute does not classify the script",
+     {"a.html": doc(GOOD_CSS, script=WIDGET),
+      "b.html": doc(GOOD_CSS, script='<script data-type="module">\n  var a = 1;\n</script>')},
+     False, ""),
+
+    ("a colour named by a keyword still has to theme",
+     {"a.html": doc(GOOD_CSS.replace("--ink: #E7E9ED;\n    --sans",
+                                     "--ink: #E7E9ED;\n    --brand: red;\n    --sans"))},
+     True, "never themes"),
+
     ("<div/> is not self-closing in HTML and must not balance the stack",
      {"a.html": doc(GOOD_CSS, body="<div/><p>x</p>")}, True, "never closed"),
 
@@ -279,6 +292,12 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
      "steps:\n  - run: python3 tests/a_test.py\n  - run: python3 tests/b.pyx\n",
      False, ""),
 
+    # A pytest/tox/wrapper step would have dropped out of the count in silence.
+    ("a test invoked by a wrapper is reported, not silently dropped",
+     doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
+     "steps:\n  - run: python3 tests/a_test.py\n  - run: pytest tests/b_test.py\n",
+     True, "cannot read"),
+
     ("a path named only in a comment is not counted",
      doc(GOOD_CSS, body='<div data-harness-count="1">x</div>'),
      "steps:\n  # python3 tests/ghost_test.py used to run here\n"
@@ -315,7 +334,7 @@ def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int
         try:
             with contextlib.redirect_stdout(sink):
                 code = A.main()
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001 - a Ctrl-C is not a finding
             # A harness that dies with a traceback where it should report is
             # the failure this whole stack is about. Reverting the media_spans
             # fix made THIS file crash rather than say which case broke.

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -214,6 +214,16 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
     ("no documents at all is a failure, not a pass",
      {}, True, "no HTML under docs/"),
 
+    ("an uncommon named colour still has to theme",
+     {"a.html": doc(GOOD_CSS.replace("--ink: #E7E9ED;\n    --sans",
+                                     "--ink: #E7E9ED;\n    --brand: rebeccapurple;\n    --sans"))},
+     True, "never themes"),
+
+    ("a <!-- comment guard in a script body is read, not refused",
+     {"a.html": doc(GOOD_CSS, script='<script>\n<!--[if IE]> x <![endif]-->\n  var a = 1;\n</script>'),
+      "b.html": doc(GOOD_CSS, script='<script>\n<!--[if IE]> x <![endif]-->\n  var a = 1;\n</script>')},
+     False, ""),
+
     ("a bare <svg/> with no children self-closes",
      {"a.html": doc(GOOD_CSS, body="<svg/><p>x</p>")}, False, ""),
 
@@ -306,7 +316,8 @@ BOARD_CASES: list[tuple[str, str, str, bool, str]] = [
 ]
 
 
-def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int, str]:
+def run_against(files: dict[str, str], workflow: str | None = None,
+                theme_invariant: set[str] | None = None) -> tuple[int, str]:
     """Point the harness at a scratch docs/ and capture what it reports.
 
     `workflow` writes a .github/workflows/checks.yml, so the board-count check
@@ -324,24 +335,20 @@ def run_against(files: dict[str, str], workflow: str | None = None) -> tuple[int
             wf.mkdir(parents=True)
             (wf / "checks.yml").write_text(workflow, encoding="utf-8")
 
-        real_docs, real_repo = A.DOCS, A.REPO
-        A.DOCS, A.REPO = docs, tmp
         buf: list[str] = []
-        # contextlib.redirect_stdout rather than monkeypatching builtins.print:
-        # the stdlib primitive exists for this and does not interact oddly with
-        # a runner that also patches print.
+        # Roots passed as arguments rather than assigned onto the module.
+        # The previous version swapped A.DOCS and A.REPO and restored them in a
+        # finally - correct here, and silently wrong under any parallel runner.
         sink = io.StringIO()
         try:
             with contextlib.redirect_stdout(sink):
-                code = A.main()
+                code = A.main(docs_root=docs, repo_root=tmp,
+                              theme_invariant=theme_invariant)
         except Exception as exc:  # noqa: BLE001 - a Ctrl-C is not a finding
             # A harness that dies with a traceback where it should report is
-            # the failure this whole stack is about. Reverting the media_spans
-            # fix made THIS file crash rather than say which case broke.
+            # the failure this whole stack is about.
             buf.append(f"the harness raised {type(exc).__name__}: {exc}")
             code = 1
-        finally:
-            A.DOCS, A.REPO = real_docs, real_repo
         return code, sink.getvalue() + "\n".join(buf)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -363,12 +370,7 @@ def check_theme_invariant_exemption() -> list[str]:
         return ["an unthemed colour passed even before the exemption was "
                 "applied; this case proves nothing as written"]
 
-    original = A.THEME_INVARIANT
-    A.THEME_INVARIANT = {"--brand"}
-    try:
-        code, output = run_against(files)
-    finally:
-        A.THEME_INVARIANT = original
+    code, output = run_against(files, theme_invariant={"--brand"})
     if code != 0:
         return [f"THEME_INVARIANT did not suppress the finding for an exempted "
                 f"token; the exemption path does not work. output: "

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -214,6 +214,24 @@ CASES: list[tuple[str, dict[str, str], bool, str]] = [
     ("no documents at all is a failure, not a pass",
      {}, True, "no HTML under docs/"),
 
+    ("<div/> is not self-closing in HTML and must not balance the stack",
+     {"a.html": doc(GOOD_CSS, body="<div/><p>x</p>")}, True, "never closed"),
+
+    ("<circle/> inside <svg> is self-closing and must balance",
+     {"a.html": doc(GOOD_CSS, body='<svg viewBox="0 0 2 2"><circle r="1"/>'
+                                   '<line x1="0" y1="0" x2="1" y2="1"/></svg>')},
+     False, ""),
+
+    ("identical bodies under <script> and <script type=module> are not one widget",
+     {"a.html": doc(GOOD_CSS, script=WIDGET),
+      "b.html": doc(GOOD_CSS, script='<script type="module">\n  var a = 1;\n</script>')},
+     True, "diverged"),
+
+    ("a > inside an attribute value does not truncate the script body",
+     {"a.html": doc(GOOD_CSS, script='<script data-x=">">\n  var a = 1;\n</script>'),
+      "b.html": doc(GOOD_CSS, script=WIDGET)},
+     False, ""),
+
     # A media query with no opening brace used to raise a bare ValueError out
     # of media_spans and kill main() with a traceback - in the file whose whole
     # promise is a path and a reason instead of a stack.

--- a/tests/docs/harness_test.py
+++ b/tests/docs/harness_test.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""The harness for the harness.
+
+`tests/docs/artifact_test.py` was verified by hand: break a thing, run it,
+watch it fail, put the change back. Six cases, done at a terminal, and the
+evidence written into a pull request description.
+
+That is exactly what that file exists to stop. It checks two documents whose
+"parses clean" and "byte-identical" claims were narrated rather than enforced,
+and it was itself narrated rather than enforced. Against the real documents it
+can only exercise the branches those two documents happen to trigger — so an
+edit to `body_at`, `THEME_RE` or `SCRIPT_RE` that reintroduces a false pass
+would be caught by nothing.
+
+It has already shipped three defects of that kind in six rounds:
+
+    a false positive   `<script>` matched bare only, so a divergent
+                       `<script type="module">` was not compared at all
+    a false negative   a colour declared once in the base and omitted from
+                       every override was never looked at
+    a mutual deferral  two checks each relying on the other to report an
+                       unreadable base :root, under a case neither covered
+
+Each was found by a reviewer, not by a test. These are those cases, committed.
+
+    python3 tests/docs/harness_test.py
+
+Standard library only.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import artifact_test as A  # noqa: E402
+
+
+def doc(style: str = "", body: str = "<p>x</p>", script: str | None = None,
+        head: str = '<!DOCTYPE html>\n<html lang="en"><head>'
+                    '<meta charset="utf-8"><title>t</title>') -> str:
+    parts = [head]
+    if style:
+        parts.append(f"<style>\n{style}\n</style>")
+    parts.append(f"</head><body>{body}")
+    if script is not None:
+        parts.append(script)
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+# A palette that satisfies every check: a dark base, a light media query, and
+# both data-theme blocks agreeing with their counterparts.
+GOOD_CSS = """
+  :root {
+    --ground: #0E1116;
+    --ink: #E7E9ED;
+    --sans: system-ui, sans-serif;
+  }
+  @media (prefers-color-scheme: light) {
+    :root { --ground: #EFEEE9; --ink: #15181D; }
+  }
+  :root[data-theme="light"] { --ground: #EFEEE9; --ink: #15181D; }
+  :root[data-theme="dark"] { --ground: #0E1116; --ink: #E7E9ED; }
+"""
+
+WIDGET = "<script>\n  var a = 1;\n</script>"
+
+# (name, {filename: content}, expect_failure, substring the report must contain)
+CASES: list[tuple[str, dict[str, str], bool, str]] = [
+
+    # ---------- check_parses ----------
+    ("a whole document passes",
+     {"a.html": doc(GOOD_CSS)}, False, ""),
+
+    ("an unclosed tag is caught",
+     {"a.html": doc(GOOD_CSS, body="<div><p>x</p>")}, True, "never closed"),
+
+    ("a crossed tag is caught",
+     {"a.html": doc(GOOD_CSS, body="<div><span>x</div></span>")},
+     True, "closes <span>"),
+
+    ("a fragment with no doctype is caught — both documents shipped as one",
+     {"a.html": doc(GOOD_CSS, head='<html lang="en"><head>'
+                                   '<meta charset="utf-8"><title>t</title>')},
+     True, "<!DOCTYPE html>"),
+
+    ("a document with no charset is caught",
+     {"a.html": doc(GOOD_CSS, head='<!DOCTYPE html>\n<html lang="en">'
+                                   "<head><title>t</title>")},
+     True, "charset"),
+
+    ("lowercase doctype and a single-quoted, reordered charset pass",
+     {"a.html": doc(GOOD_CSS, head="<!doctype html>\n<html lang='en'><head>"
+                                   "<meta name='x' content='y' charset='UTF-8'>"
+                                   "<title>t</title>")},
+     False, ""),
+
+    ("the older http-equiv charset passes",
+     {"a.html": doc(GOOD_CSS, head='<!DOCTYPE html>\n<html lang="en"><head>'
+                                   '<meta http-equiv="Content-Type" '
+                                   'content="text/html; charset=UTF-8">'
+                                   "<title>t</title>")},
+     False, ""),
+
+    # ---------- check_shared_widget ----------
+    ("two documents with the same widget pass",
+     {"a.html": doc(GOOD_CSS, script=WIDGET),
+      "b.html": doc(GOOD_CSS, script=WIDGET)}, False, ""),
+
+    ("one space of drift between two widgets is caught",
+     {"a.html": doc(GOOD_CSS, script=WIDGET),
+      "b.html": doc(GOOD_CSS, script=WIDGET.replace("var a", "var  a"))},
+     True, "diverged"),
+
+    # The false pass that shipped. A bare-<script> pattern did not merely
+    # mis-handle this - it did not collect it, so the check compared one script
+    # against nothing and reported agreement.
+    ("drift hidden behind <script type=\"module\"> is caught",
+     {"a.html": doc(GOOD_CSS, script=WIDGET),
+      "b.html": doc(GOOD_CSS, script='<script type="module">\n  var b = 2;\n</script>')},
+     True, "diverged"),
+
+    ("an external <script src> is reported, not skipped",
+     {"a.html": doc(GOOD_CSS, script='<script src="tabs.js"></script>')},
+     True, "external script"),
+
+    # ---------- check_theme_parity ----------
+    ("a token differing between the toggle and the OS preference is caught",
+     {"a.html": doc(GOOD_CSS.replace(
+         ':root[data-theme="light"] { --ground: #EFEEE9;',
+         ':root[data-theme="light"] { --ground: #FF0000;'))},
+     True, "would disagree"),
+
+    ("a token differing between the base and its data-theme twin is caught",
+     {"a.html": doc(GOOD_CSS.replace(
+         ':root[data-theme="dark"] { --ground: #0E1116;',
+         ':root[data-theme="dark"] { --ground: #FF0000;'))},
+     True, "must match"),
+
+    ("data-theme blocks with no media query are caught",
+     {"a.html": doc("""
+  :root { --ground: #0E1116; }
+  :root[data-theme="light"] { --ground: #EFEEE9; }
+  :root[data-theme="dark"] { --ground: #0E1116; }
+""")},
+     True, "OS preference is ignored"),
+
+    # ---------- check_every_colour_themes ----------
+    ("a colour declared only in the base is caught — this was --ultraviolet",
+     {"a.html": doc(GOOD_CSS.replace("--ink: #E7E9ED;\n    --sans",
+                                     "--ink: #E7E9ED;\n    --accent: #A855F7;\n    --sans"))},
+     True, "never themes"),
+
+    ("a colour missing from just one override is caught",
+     {"a.html": doc(GOOD_CSS.replace(
+         ':root[data-theme="dark"] { --ground: #0E1116; --ink: #E7E9ED; }',
+         ':root[data-theme="dark"] { --ground: #0E1116; }'))},
+     True, "missing from"),
+
+    ("a non-colour token is not required to theme",
+     {"a.html": doc(GOOD_CSS)}, False, ""),
+
+    # ---------- the mutual-deferral gap ----------
+    # A themed document whose base :root cannot be read, with no data-theme
+    # block. check_theme_parity short-circuited before reading the base;
+    # check_every_colour_themes deferred to it by comment. Both went quiet.
+    ("an unreadable base :root is reported even with no data-theme block",
+     {"a.html": doc("""
+  :root {
+    --ground: #0E1116;
+  @media (prefers-color-scheme: light) {
+    :root { --ground: #EFEEE9; }
+  }
+""")},
+     True, "could not be read"),
+
+    # ---------- the scanners ----------
+    ("a brace inside a CSS string does not desync the block reader",
+     {"a.html": doc(GOOD_CSS + '\n  .x::before { content: "{"; }\n')},
+     False, ""),
+
+    ("a semicolon inside a CSS string does not truncate a declaration",
+     {"a.html": doc(GOOD_CSS.replace("--sans: system-ui, sans-serif;",
+                                     '--sep: ";";\n    --sans: system-ui, sans-serif;'))},
+     False, ""),
+
+    ("a reformatted :root with no indent is still found",
+     {"a.html": doc(GOOD_CSS.replace("\n  :root {", "\n:root{"))}, False, ""),
+
+    # ---------- vacuous passes ----------
+    ("an unthemed document is not required to have a :root",
+     {"a.html": doc("", body="<p>plain</p>")}, False, ""),
+
+    ("no documents at all is a failure, not a pass",
+     {}, True, "no HTML under docs/"),
+]
+
+
+def run_against(files: dict[str, str]) -> tuple[int, str]:
+    """Point the harness at a scratch docs/ and capture what it reports."""
+    tmp = Path(tempfile.mkdtemp())
+    try:
+        docs = tmp / "docs"
+        docs.mkdir()
+        for name, content in files.items():
+            (docs / name).write_text(content, encoding="utf-8")
+
+        real_docs, real_repo = A.DOCS, A.REPO
+        A.DOCS, A.REPO = docs, tmp
+        buf: list[str] = []
+        import builtins
+        original = builtins.print
+        builtins.print = lambda *a, **k: buf.append(" ".join(str(x) for x in a))
+        try:
+            code = A.main()
+        finally:
+            builtins.print = original
+            A.DOCS, A.REPO = real_docs, real_repo
+        return code, "\n".join(buf)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> int:
+    failures = []
+    for name, files, expect_failure, needle in CASES:
+        code, output = run_against(files)
+        failed = code != 0
+        if failed != expect_failure:
+            failures.append(
+                f"{name}\n    expected {'a failure' if expect_failure else 'a pass'}, "
+                f"got {'a failure' if failed else 'a pass'}\n"
+                f"    output: {output.strip()[:300]}")
+        elif expect_failure and needle and needle not in output:
+            failures.append(
+                f"{name}\n    failed as expected, but for the wrong reason: "
+                f"{needle!r} not in the report\n    output: {output.strip()[:300]}")
+
+    if failures:
+        print("harness test: FAILED")
+        for line in failures:
+            print(f"  {line}")
+        return 1
+
+    fails = sum(1 for _, _, e, _ in CASES if e)
+    print(f"harness test: {len(CASES)} cases behave — {fails} that must fail "
+          f"do, {len(CASES) - fails} that must pass do")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two HTML documents and the harness that checks them. This is the split the review on #40 asked for.

| file | what it is |
|---|---|
| `docs/big-board.html` | program status — lanes, live CI, the three dead workflows, the defect ledger, roster, open work |
| `docs/csi/shodann/calibration-brief.html` | SHODANN's introduction and the clearance register |
| `tests/docs/artifact_test.py` | checks both of the above, wired into `checks.yml` |

> **Correction.** An earlier revision of this description said *"No harness reads `docs/`, so nothing here can move a test."* That was true of the state this PR started from and **false of the state it produces** — this PR adds a harness that reads `docs/` and runs in CI. Caught by review. A forensic document that misdescribes its own diff undercuts everything else in it, so it is corrected here rather than quietly reworded.

## They were fragments, and that was a real defect

Both were authored as **embedded artifact fragments**, where the host supplies the document scaffolding. Committed as files opened from disk, they had no `<!DOCTYPE>`, no `<html>`/`<head>`/`<body>`, and no `<meta charset>` — so a browser would parse them in quirks mode with the encoding unspecified. Correct where they were rendered, wrong here. Caught by review on #40; both are now whole documents.

## Placement

**`docs/big-board.html`** — repository-level, so it sits at the top of `docs/` rather than under `docs/csi/`. It covers the CI chain and the workflow archaeology as much as the roster.

**`docs/csi/shodann/calibration-brief.html`** — deliberately *not* beside `.claude/skills/shodann-voice/SKILL.md`, which would be the intuitive "her folder." `ROSTER.md` sets the rule:

> `.claude/agents/shodann.md` and `.claude/skills/shodann-voice/SKILL.md` are byte-identical to the copies in `algorithm-shodann` … **anything true only of this repository stays out of those two files.**

The brief charts seven agents that exist only here. Putting it in the shared folder invites it into a sync where most of it would be false. `docs/csi/` is the established home for repo-specific SHODANN prose — `ROSTER.md`'s own SHODANN section is exactly that.

**Verified rather than argued.** The claim that `floor_test.py`'s glob doesn't reach `docs/` was asserted in an earlier revision. Widening it to `docs/**/*.md` produces:

```
lint test: FAILED
  ROSTER.md is now loaded by the harness; it describes the shared-base
  arrangement without being one, so it will false-positive
```

The guard fires and names the failure it prevents.

## The board's structural device

Filled mark = **verified by a run**. Hollow mark = **asserted only**.

That is the distinction this repository has spent two days on. Every count on the board was read off a green run and the live API rather than from memory, and the board now says so in its masthead rather than only its footer:

> **Static snapshot, not a live board.** … It does not update, and it goes wrong on the next merge rather than going blank.

Whether it should stop calling itself a board at all is #43.

## `tests/docs/artifact_test.py`

Added after a review named a double standard I have no defence of: the SHODANN shared base got a version stamp and a lint check *because comparing bytes by hand was judged insufficient*, and these two documents got a comment — a comment which itself explains that two earlier copies of the same widget had already diverged. A note about drift, holding the line against drift, by itself.

Three checks, deliberately persona-unaware so `ROSTER.md` cannot be swept into persona scoring:

1. **Every document parses whole** — tag balance plus scaffolding, read from the parse rather than by substring, so `<!doctype html>` and `<meta charset='utf-8'>` pass.
2. **Every inline script under `docs/` is the same script** — phrased as *all agree*, so a third document cannot introduce a third variant.
3. **The two routes to a theme must agree** — `prefers-color-scheme` and `data-theme` are written separately by construction and nothing stopped them drifting.

Writing check 3 surfaced drift already present: **the two files use opposite conventions**, dark-base-with-light-media-query versus the reverse. Both valid; invisible to a byte comparison.

### It shipped a false pass, and that is recorded rather than fixed quietly

`SCRIPT_RE` matched a bare `<script>` only, so a document using `<script type="module">` was not collected at all — the dict held one entry and the check reported *"one shared widget"* across two documents whose widgets differed. Built as a real case, not reasoned about:

```
docs artifact test: 2 documents parse whole, one shared widget
```

Skip-and-pass, in the file written to stop skip-and-pass, three commits after adding it. Closed.

### Every branch verified by breaking it

```
MUST FAIL   dropped </table>            → "</div> closes <table> opened on line 496"
MUST FAIL   missing charset             → "a fragment, not a document"
MUST FAIL   one space added to the JS   → "1928 chars … 1927 chars … diverged"
MUST FAIL   one hex changed in a theme  → "the toggle and the OS preference would disagree"
MUST PASS   lowercase doctype, single-quoted reordered charset
MUST PASS   reformatted `:root{`, a brace inside a CSS string
```

The must-pass cases exist because the first version of this harness would have failed all of them.

## Verification

```
floor 10 · lint 52 · examples 23 · extraction 6 · stray 7 · kevin 19 · docs 2
```

Seven harnesses in CI, where two days ago none ran.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH6BqCvRf7NsZDBX2eRvkj